### PR TITLE
Use timestamp_opt() instead of timestamp() in test

### DIFF
--- a/src/parse_datetime.rs
+++ b/src/parse_datetime.rs
@@ -255,7 +255,7 @@ mod tests {
             ];
 
             for offset in offsets {
-                let time = Utc.timestamp(offset, 0);
+                let time = Utc.timestamp_opt(offset, 0).unwrap();
                 let dt = from_str(format!("@{}", offset));
                 assert_eq!(dt.unwrap(), time);
             }


### PR DESCRIPTION
This PR replaces the use of the deprecated `timestamp()` with `timestamp_opt()`.