### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
         echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
     - name: Upload coverage results (to Codecov.io)
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       # if: steps.vars.outputs.HAS_CODECOV_TOKEN
       with:
         # token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Reverts uutils/parse_datetime#48 because they tagged the version prematurely, see https://github.com/codecov/codecov-action/issues/1089