### PR TITLE
Add support to parse relative modifiers from date strings

### DIFF
--- a/src/parse_relative_time.rs
+++ b/src/parse_relative_time.rs
@@ -1,92 +1,66 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use crate::ParseDateTimeError;
-use chrono::{Duration, Local, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike};
 use regex::Regex;
-/// Parses a relative time string and returns a `Duration` representing the
-/// relative time.
-///Regex
-/// # Arguments
-///
-/// * `s` - A string slice representing the relative time.
-///
-///
-/// # Supported formats
-///
-/// The function supports the following formats for relative time:
-///
-/// * `num` `unit` (e.g., "-1 hour", "+3 days")
-/// * `unit` (e.g., "hour", "day")
-/// * "now" or "today"
-/// * "yesterday"
-/// * "tomorrow"
-/// * use "ago" for the past
-///
-/// `[num]` can be a positive or negative integer.
-/// [unit] can be one of the following: "fortnight", "week", "day", "hour",
-/// "minute", "min", "second", "sec" and their plural forms.
-///
-/// It is also possible to pass "1 hour 2 minutes" or "2 days and 2 hours"
-///
-/// # Returns
-///
-/// * `Ok(Duration)` - If the input string can be parsed as a relative time
-/// * `Err(ParseDateTimeError)` - If the input string cannot be parsed as a relative time
-///
-/// # Errors
-///
-/// This function will return `Err(ParseDateTimeError::InvalidInput)` if the input string
-/// cannot be parsed as a relative time.
-///
-/// ```
-pub fn parse_relative_time(s: &str) -> Result<Duration, ParseDateTimeError> {
-    parse_relative_time_at_date(Utc::now().date_naive(), s)
-}
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::ops::Add;
 
-/// Parses a duration string and returns a `Duration` instance, with the duration
-/// calculated from the specified date.
+/// Parses a date modification string and performs the operation on the given `DateTime<TimeZone>`
+/// object and returns a new `DateTime<TimeZone>` as a `Result`.
+///
 ///
 /// # Arguments
 ///
-/// * `date` - A `Date` instance representing the base date for the calculation
+/// * `date` - A `DateTime<TimeZone>` instance representing the base date for the calculation
 /// * `s` - A string slice representing the relative time.
 ///
 /// # Errors
 ///
 /// This function will return `Err(ParseDateTimeError::InvalidInput)` if the input string
 /// cannot be parsed as a relative time.
-/// ```
-pub fn parse_relative_time_at_date(
-    date: NaiveDate,
+pub fn dt_from_relative<Tz: TimeZone>(
     s: &str,
-) -> Result<Duration, ParseDateTimeError> {
+    date: DateTime<Tz>,
+) -> Result<DateTime<Tz>, ParseDateTimeError> {
+    if s.trim().is_empty() {
+        return Ok(date);
+    }
+
     let time_pattern: Regex = Regex::new(
-        r"(?x)
-        (?:(?P<value>[-+]?\d*)\s*)?
+        r"(?ix)
+        (?:(?P<value>[-+]?\s*\d*)\s*)?
         (\s*(?P<direction>next|last)?\s*)?
-        (?P<unit>years?|months?|fortnights?|weeks?|days?|hours?|h|minutes?|mins?|m|seconds?|secs?|s|yesterday|tomorrow|now|today)
+        (?P<absolute>years?|months?|fortnights?|weeks?|days?|hours?|h|minutes?|mins?|m|seconds?|secs?|s)?
+        (?P<relative>yesterday|tomorrow|now|today)?
         (\s*(?P<separator>and|,)?\s*)?
         (\s*(?P<ago>ago)?)?",
-    )?;
+    ).unwrap();
 
-    let mut total_duration = Duration::seconds(0);
     let mut is_ago = s.contains(" ago");
     let mut captures_processed = 0;
-    let mut total_length = 0;
 
-    for capture in time_pattern.captures_iter(s) {
+    let mut chrono_map: HashMap<ChronoUnit, i64> = HashMap::new();
+
+    let mut time: Option<u32> = None;
+
+    for capture in time_pattern.captures_iter(s.trim()) {
         captures_processed += 1;
-
         let value_str = capture
             .name("value")
             .ok_or(ParseDateTimeError::InvalidInput)?
             .as_str();
-        let value = if value_str.is_empty() {
-            1
-        } else {
+
+        let mut value = if !value_str.is_empty() {
             value_str
+                .chars()
+                .filter(|char| !char.is_ascii_whitespace())
+                .collect::<String>()
                 .parse::<i64>()
                 .map_err(|_| ParseDateTimeError::InvalidInput)?
+        } else {
+            1
         };
 
         if let Some(direction) = capture.name("direction") {
@@ -95,528 +69,353 @@ pub fn parse_relative_time_at_date(
             }
         }
 
-        let unit = capture
-            .name("unit")
-            .ok_or(ParseDateTimeError::InvalidInput)?
-            .as_str();
-
         if capture.name("ago").is_some() {
             is_ago = true;
         }
 
-        let duration = match unit {
-            "years" | "year" => Duration::days(value * 365),
-            "months" | "month" => Duration::days(value * 30),
-            "fortnights" | "fortnight" => Duration::weeks(value * 2),
-            "weeks" | "week" => Duration::weeks(value),
-            "days" | "day" => Duration::days(value),
-            "hours" | "hour" | "h" => Duration::hours(value),
-            "minutes" | "minute" | "mins" | "min" | "m" => Duration::minutes(value),
-            "seconds" | "second" | "secs" | "sec" | "s" => Duration::seconds(value),
-            "yesterday" => Duration::days(-1),
-            "tomorrow" => Duration::days(1),
-            "now" | "today" => Duration::zero(),
-            _ => return Err(ParseDateTimeError::InvalidInput),
-        };
-        let neg_duration = -duration;
-        total_duration =
-            match total_duration.checked_add(if is_ago { &neg_duration } else { &duration }) {
-                Some(duration) => duration,
-                None => return Err(ParseDateTimeError::InvalidInput),
-            };
+        if value > 0 && is_ago {
+            value *= -1;
+        }
 
-        // Calculate the total length of the matched substring
-        if let Some(m) = capture.get(0) {
-            total_length += m.end() - m.start();
+        match (capture.name("absolute"), capture.name("relative")) {
+            (None, None) => {
+                // time cannot be set twice and time cannot be negative
+                if value < 0 || time.is_some() {
+                    return Err(ParseDateTimeError::InvalidInput);
+                }
+                // Time values cannot start with '+' or '-' to be consistent with GNU
+                if value_str.starts_with('+') || value_str.starts_with('-') {
+                    return Err(ParseDateTimeError::InvalidInput);
+                }
+                time = Some(value as u32);
+            }
+            (Some(absolute), None) => {
+                process_absolute(
+                    absolute.as_str().to_ascii_lowercase(),
+                    &mut chrono_map,
+                    value,
+                )?;
+            }
+            (None, Some(relative)) => {
+                // time cannot be set twice and time cannot be negative
+                if value < 0 || time.is_some() {
+                    return Err(ParseDateTimeError::InvalidInput);
+                }
+                // Use value_str as a way to check if user passed in a value.
+                // If they did not then we should not interpret `value = 1` as a time
+                if !value_str.is_empty() {
+                    time = Some(value as u32);
+                }
+                process_relative(relative.as_str().to_string(), &mut chrono_map)?;
+            }
+            (Some(_), Some(_)) => {
+                /* Doesn't appear to be possibly due to the way the
+                regular expression is structured, and how the iterator works.
+                There is a test case in test_edge_cases() that passes.
+                */
+            }
         }
     }
-
-    // Check if the entire input string has been captured
-    if total_length != s.len() {
+    if captures_processed == 0 {
         return Err(ParseDateTimeError::InvalidInput);
     }
 
-    if captures_processed == 0 {
-        Err(ParseDateTimeError::InvalidInput)
-    } else {
-        let time_now = Local::now().date_naive();
-        let date_duration = date - time_now;
+    let mut datetime = match time {
+        None => date,
+        Some(time) => {
+            let hour = time / 100;
+            let minute = time % 100;
+            if hour >= 24 || minute >= 60 {
+                return Err(ParseDateTimeError::InvalidInput);
+            }
+            date.with_hour(hour).unwrap().with_minute(minute).unwrap()
+        }
+    };
 
-        Ok(total_duration + date_duration)
+    if let Some(months) = chrono_map.remove(&ChronoUnit::Month) {
+        process_months(&mut datetime, months);
+    }
+
+    // Not doing things like months/years before other elements leads to improper output.
+    let sorted = {
+        let mut v = chrono_map.into_iter().collect::<Vec<(ChronoUnit, i64)>>();
+        v.sort_by(|a, b| a.0.cmp(&b.0));
+        v
+    };
+    for (chrono, value) in sorted.into_iter() {
+        match chrono {
+            ChronoUnit::Month => { /* Not possible */ }
+            ChronoUnit::Fortnight => {
+                datetime = datetime.add(Duration::weeks(value * 2));
+            }
+            ChronoUnit::Week => {
+                datetime = datetime.add(Duration::weeks(value));
+            }
+            ChronoUnit::Day => {
+                datetime = datetime.add(Duration::days(value));
+            }
+            ChronoUnit::Hour => {
+                datetime = datetime.add(Duration::hours(value));
+            }
+            ChronoUnit::Minute => {
+                datetime = datetime.add(Duration::minutes(value));
+            }
+            ChronoUnit::Second => {
+                datetime = datetime.add(Duration::seconds(value));
+            }
+        }
+    }
+    Ok(datetime)
+}
+#[allow(clippy::map_entry)]
+fn add_unit(map: &mut HashMap<ChronoUnit, i64>, unit: ChronoUnit, time: i64) {
+    if map.contains_key(&unit) {
+        *map.get_mut(&unit).unwrap() += time;
+    } else {
+        map.insert(unit, time);
+    }
+}
+
+#[allow(clippy::match_overlapping_arm, overlapping_range_endpoints)]
+fn process_months<Tz: TimeZone>(date: &mut DateTime<Tz>, months: i64) {
+    let mut years = months / 12;
+    let current_month = date.month() as i64;
+    let potential_month = current_month + months % 12;
+    const JANUARY: i64 = 1;
+    const DECEMBER: i64 = 12;
+    let new_month = match potential_month {
+        JANUARY..=DECEMBER => potential_month,
+        -12..=JANUARY => {
+            years -= 1;
+            DECEMBER + potential_month
+        }
+        DECEMBER.. => {
+            years += 1;
+            potential_month - DECEMBER
+        }
+        _ => panic!("IMPOSSIBLE!"),
+    } as u32;
+
+    *date = date
+        .with_day(28)
+        .unwrap()
+        .with_month(new_month)
+        .unwrap()
+        .with_year(date.year() + years as i32)
+        .unwrap()
+        .add(Duration::days(date.day() as i64 - 28));
+}
+
+fn process_absolute(
+    unit: String,
+    chrono_map: &mut HashMap<ChronoUnit, i64>,
+    value: i64,
+) -> Result<(), ParseDateTimeError> {
+    match unit.as_bytes() {
+        b"years" | b"year" => add_unit(chrono_map, ChronoUnit::Month, value * 12),
+        b"months" | b"month" => add_unit(chrono_map, ChronoUnit::Month, value),
+        b"fortnights" | b"fortnight" => add_unit(chrono_map, ChronoUnit::Fortnight, value),
+        b"weeks" | b"week" => add_unit(chrono_map, ChronoUnit::Week, value),
+        b"days" | b"day" => add_unit(chrono_map, ChronoUnit::Day, value),
+        b"hours" | b"hour" | b"h" => add_unit(chrono_map, ChronoUnit::Hour, value),
+        b"minutes" | b"minute" | b"mins" | b"min" | b"m" => {
+            add_unit(chrono_map, ChronoUnit::Minute, value)
+        }
+        b"seconds" | b"second" | b"secs" | b"sec" | b"s" => {
+            add_unit(chrono_map, ChronoUnit::Second, value)
+        }
+        _ => return Err(ParseDateTimeError::InvalidInput),
+    };
+    Ok(())
+}
+
+fn process_relative(
+    unit: String,
+    chrono_map: &mut HashMap<ChronoUnit, i64>,
+) -> Result<(), ParseDateTimeError> {
+    match unit.as_bytes() {
+        b"yesterday" => add_unit(chrono_map, ChronoUnit::Day, -1),
+        b"tomorrow" => add_unit(chrono_map, ChronoUnit::Day, 1),
+        b"now" | b"today" => { /*No processing needed*/ }
+        _ => return Err(ParseDateTimeError::InvalidInput),
+    }
+    Ok(())
+}
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq)]
+enum ChronoUnit {
+    Month,
+    Fortnight,
+    Week,
+    Day,
+    Hour,
+    Minute,
+    Second,
+}
+
+impl ChronoUnit {
+    fn map_to_int(&self) -> u8 {
+        match self {
+            ChronoUnit::Month => 7,
+            ChronoUnit::Fortnight => 6,
+            ChronoUnit::Week => 5,
+            ChronoUnit::Day => 4,
+            ChronoUnit::Hour => 3,
+            ChronoUnit::Minute => 2,
+            ChronoUnit::Second => 1,
+        }
+    }
+}
+
+impl PartialOrd for ChronoUnit {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.map_to_int().cmp(&other.map_to_int()))
+    }
+}
+
+impl Ord for ChronoUnit {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.map_to_int().cmp(&other.map_to_int())
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use super::ParseDateTimeError;
-    use super::{parse_relative_time, parse_relative_time_at_date};
-    use chrono::{Duration, Local, NaiveDate, Utc};
+    use super::dt_from_relative;
+    use chrono::DateTime;
 
     #[test]
-    fn test_years() {
-        assert_eq!(
-            parse_relative_time("1 year").unwrap(),
-            Duration::seconds(31_536_000)
-        );
-        assert_eq!(
-            parse_relative_time("-2 years").unwrap(),
-            Duration::seconds(-63_072_000)
-        );
-        assert_eq!(
-            parse_relative_time("2 years ago").unwrap(),
-            Duration::seconds(-63_072_000)
-        );
-        assert_eq!(
-            parse_relative_time("year").unwrap(),
-            Duration::seconds(31_536_000)
-        );
+    fn test_parse_date_from_modifier_ok() {
+        let format = "%Y %b %d %H:%M:%S.%f %z";
+        let input = [
+            (
+                "1000",
+                DateTime::parse_from_str("2022 May 15 10:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "1000 yesterday",
+                DateTime::parse_from_str("2022 May 14 10:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "1000 yesterday next month",
+                DateTime::parse_from_str("2022 Jun 14 10:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "1000 yesterday month",
+                DateTime::parse_from_str("2022 Jun 14 10:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "last year",
+                DateTime::parse_from_str("2021 May 15 00:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "yesterday 1223",
+                DateTime::parse_from_str("2022 May 14 12:23:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "yesterday month",
+                DateTime::parse_from_str("2022 Jun 14 00:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "+01MONTH",
+                DateTime::parse_from_str("2022 Jun 15 00:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "+01MONTH 1545",
+                DateTime::parse_from_str("2022 Jun 15 15:45:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "00001year-000000001year+\t12months",
+                DateTime::parse_from_str("2023 May 15 00:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "",
+                DateTime::parse_from_str("2022 May 15 00:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "30SecONDS1houR",
+                DateTime::parse_from_str("2022 May 15 01:00:30.0 +0000", format).unwrap(),
+            ),
+            (
+                "30     \t\n\t SECONDS000050000houR-10000yearS",
+                DateTime::parse_from_str("-7972 Jan 27 08:00:30.0 +0000", format).unwrap(),
+            ),
+            (
+                "+0000111MONTHs -   20    yearS 100000day",
+                DateTime::parse_from_str("2285 May 30 00:00:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "100 week + 0024HOUrs - 50 minutes",
+                DateTime::parse_from_str("2024 Apr 14 23:10:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "-100 MONTHS 300 days + 20 \t YEARS 130",
+                DateTime::parse_from_str("2034 Nov 11 01:30:00.0 +0000", format).unwrap(),
+            ),
+        ];
+
+        let date0 = DateTime::parse_from_str("2022 May 15 00:00:00.0 +0000", format).unwrap();
+        for (modifier, expected) in input {
+            assert_eq!(dt_from_relative(modifier, date0).unwrap(), expected);
+        }
     }
 
     #[test]
-    fn test_months() {
-        assert_eq!(
-            parse_relative_time("1 month").unwrap(),
-            Duration::seconds(2_592_000)
-        );
-        assert_eq!(
-            parse_relative_time("1 month and 2 weeks").unwrap(),
-            Duration::seconds(3_801_600)
-        );
-        assert_eq!(
-            parse_relative_time("1 month and 2 weeks ago").unwrap(),
-            Duration::seconds(-3_801_600)
-        );
-        assert_eq!(
-            parse_relative_time("2 months").unwrap(),
-            Duration::seconds(5_184_000)
-        );
-        assert_eq!(
-            parse_relative_time("month").unwrap(),
-            Duration::seconds(2_592_000)
-        );
+    fn test_edge_cases() {
+        let format = "%Y %b %d %H:%M:%S.%f %z";
+        let input = [
+            (
+                "1 month 1230",
+                DateTime::parse_from_str("2022 Aug 31 00:00:00.0 +0000", format).unwrap(),
+                DateTime::parse_from_str("2022 Oct 1 12:30:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "2 month 1230",
+                DateTime::parse_from_str("2022 Aug 31 00:00:00.0 +0000", format).unwrap(),
+                DateTime::parse_from_str("2022 Oct 31 12:30:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "year 1230",
+                DateTime::parse_from_str("2020 Feb 29 00:00:00.0 +0000", format).unwrap(),
+                DateTime::parse_from_str("2021 Mar 1 12:30:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "100 year 1230",
+                DateTime::parse_from_str("2020 Feb 29 00:00:00.0 +0000", format).unwrap(),
+                DateTime::parse_from_str("2120 Feb 29 12:30:00.0 +0000", format).unwrap(),
+            ),
+            (
+                "101 year 1230",
+                DateTime::parse_from_str("2020 Feb 29 00:00:00.0 +0000", format).unwrap(),
+                DateTime::parse_from_str("2121 Mar 1 12:30:00.0 +0000", format).unwrap(),
+            ),
+            (
+                " month yesterday",
+                DateTime::parse_from_str("2020 Feb 29 00:00:00.0 +1000", format).unwrap(),
+                DateTime::parse_from_str("2020 Mar 28 00:00:00.0 +1000", format).unwrap(),
+            ),
+        ];
+
+        for (modifier, input_dt, expected_dt) in input {
+            assert_eq!(dt_from_relative(modifier, input_dt).unwrap(), expected_dt);
+        }
     }
 
     #[test]
-    fn test_fortnights() {
-        assert_eq!(
-            parse_relative_time("1 fortnight").unwrap(),
-            Duration::seconds(1_209_600)
-        );
-        assert_eq!(
-            parse_relative_time("3 fortnights").unwrap(),
-            Duration::seconds(3_628_800)
-        );
-        assert_eq!(
-            parse_relative_time("fortnight").unwrap(),
-            Duration::seconds(1_209_600)
-        );
-    }
+    fn test_parse_date_from_modifier_err() {
+        let format = "%Y %b %d %H:%M:%S.%f %z";
 
-    #[test]
-    fn test_weeks() {
-        assert_eq!(
-            parse_relative_time("1 week").unwrap(),
-            Duration::seconds(604_800)
-        );
-        assert_eq!(
-            parse_relative_time("1 week 3 days").unwrap(),
-            Duration::seconds(864_000)
-        );
-        assert_eq!(
-            parse_relative_time("1 week 3 days ago").unwrap(),
-            Duration::seconds(-864_000)
-        );
-        assert_eq!(
-            parse_relative_time("-2 weeks").unwrap(),
-            Duration::seconds(-1_209_600)
-        );
-        assert_eq!(
-            parse_relative_time("2 weeks ago").unwrap(),
-            Duration::seconds(-1_209_600)
-        );
-        assert_eq!(
-            parse_relative_time("week").unwrap(),
-            Duration::seconds(604_800)
-        );
-    }
+        let input = [
+            "100000000000000000000000000000000000000 Years",
+            "1000 days 1000 100",
+            "1000 1200",
+            "1000 yesterday 1200",
+        ];
 
-    #[test]
-    fn test_days() {
-        assert_eq!(
-            parse_relative_time("1 day").unwrap(),
-            Duration::seconds(86400)
-        );
-        assert_eq!(
-            parse_relative_time("2 days ago").unwrap(),
-            Duration::seconds(-172_800)
-        );
-        assert_eq!(
-            parse_relative_time("-2 days").unwrap(),
-            Duration::seconds(-172_800)
-        );
-        assert_eq!(
-            parse_relative_time("day").unwrap(),
-            Duration::seconds(86400)
-        );
-    }
-
-    #[test]
-    fn test_hours() {
-        assert_eq!(
-            parse_relative_time("1 hour").unwrap(),
-            Duration::seconds(3600)
-        );
-        assert_eq!(
-            parse_relative_time("1 hour ago").unwrap(),
-            Duration::seconds(-3600)
-        );
-        assert_eq!(
-            parse_relative_time("-2 hours").unwrap(),
-            Duration::seconds(-7200)
-        );
-        assert_eq!(
-            parse_relative_time("hour").unwrap(),
-            Duration::seconds(3600)
-        );
-    }
-
-    #[test]
-    fn test_minutes() {
-        assert_eq!(
-            parse_relative_time("1 minute").unwrap(),
-            Duration::seconds(60)
-        );
-        assert_eq!(
-            parse_relative_time("2 minutes").unwrap(),
-            Duration::seconds(120)
-        );
-        assert_eq!(parse_relative_time("min").unwrap(), Duration::seconds(60));
-    }
-
-    #[test]
-    fn test_seconds() {
-        assert_eq!(
-            parse_relative_time("1 second").unwrap(),
-            Duration::seconds(1)
-        );
-        assert_eq!(
-            parse_relative_time("2 seconds").unwrap(),
-            Duration::seconds(2)
-        );
-        assert_eq!(parse_relative_time("sec").unwrap(), Duration::seconds(1));
-    }
-
-    #[test]
-    fn test_relative_days() {
-        assert_eq!(parse_relative_time("now").unwrap(), Duration::seconds(0));
-        assert_eq!(parse_relative_time("today").unwrap(), Duration::seconds(0));
-        assert_eq!(
-            parse_relative_time("yesterday").unwrap(),
-            Duration::seconds(-86400)
-        );
-        assert_eq!(
-            parse_relative_time("tomorrow").unwrap(),
-            Duration::seconds(86400)
-        );
-    }
-
-    #[test]
-    fn test_no_spaces() {
-        assert_eq!(parse_relative_time("-1hour").unwrap(), Duration::hours(-1));
-        assert_eq!(parse_relative_time("+3days").unwrap(), Duration::days(3));
-        assert_eq!(parse_relative_time("2weeks").unwrap(), Duration::weeks(2));
-        assert_eq!(
-            parse_relative_time("2weeks 1hour").unwrap(),
-            Duration::seconds(1_213_200)
-        );
-        assert_eq!(
-            parse_relative_time("2weeks 1hour ago").unwrap(),
-            Duration::seconds(-1_213_200)
-        );
-        assert_eq!(
-            parse_relative_time("+4months").unwrap(),
-            Duration::days(4 * 30)
-        );
-        assert_eq!(
-            parse_relative_time("-2years").unwrap(),
-            Duration::days(-2 * 365)
-        );
-        assert_eq!(
-            parse_relative_time("15minutes").unwrap(),
-            Duration::minutes(15)
-        );
-        assert_eq!(
-            parse_relative_time("-30seconds").unwrap(),
-            Duration::seconds(-30)
-        );
-        assert_eq!(
-            parse_relative_time("30seconds ago").unwrap(),
-            Duration::seconds(-30)
-        );
-    }
-
-    #[test]
-    fn test_invalid_input() {
-        let result = parse_relative_time("foobar");
-        println!("{result:?}");
-        assert_eq!(result, Err(ParseDateTimeError::InvalidInput));
-
-        let result = parse_relative_time("invalid 1");
-        assert_eq!(result, Err(ParseDateTimeError::InvalidInput));
-        // Fails for now with a panic
-        /*        let result = parse_relative_time("777777777777777771m");
-        match result {
-            Err(ParseDateTimeError::InvalidInput) => assert!(true),
-            _ => assert!(false),
-        }*/
-    }
-
-    #[test]
-    fn test_parse_relative_time_at_date() {
-        let date = NaiveDate::from_ymd_opt(2014, 9, 5).unwrap();
-        let now = Local::now().date_naive();
-        let days_diff = (date - now).num_days();
-
-        assert_eq!(
-            parse_relative_time_at_date(date, "1 day").unwrap(),
-            Duration::days(days_diff + 1)
-        );
-
-        assert_eq!(
-            parse_relative_time_at_date(date, "2 hours").unwrap(),
-            Duration::days(days_diff) + Duration::hours(2)
-        );
-    }
-
-    #[test]
-    fn test_invalid_input_at_date() {
-        let date = NaiveDate::from_ymd_opt(2014, 9, 5).unwrap();
-        assert!(matches!(
-            parse_relative_time_at_date(date, "invalid"),
-            Err(ParseDateTimeError::InvalidInput)
-        ));
-    }
-
-    #[test]
-    fn test_direction() {
-        assert_eq!(
-            parse_relative_time("last hour").unwrap(),
-            Duration::seconds(-3600)
-        );
-        assert_eq!(
-            parse_relative_time("next year").unwrap(),
-            Duration::days(365)
-        );
-        assert_eq!(parse_relative_time("next week").unwrap(), Duration::days(7));
-        assert_eq!(
-            parse_relative_time("last month").unwrap(),
-            Duration::days(-30)
-        );
-    }
-
-    #[test]
-    fn test_duration_parsing() {
-        assert_eq!(
-            parse_relative_time("1 year").unwrap(),
-            Duration::seconds(31_536_000)
-        );
-        assert_eq!(
-            parse_relative_time("-2 years").unwrap(),
-            Duration::seconds(-63_072_000)
-        );
-        assert_eq!(
-            parse_relative_time("2 years ago").unwrap(),
-            Duration::seconds(-63_072_000)
-        );
-        assert_eq!(
-            parse_relative_time("year").unwrap(),
-            Duration::seconds(31_536_000)
-        );
-
-        assert_eq!(
-            parse_relative_time("1 month").unwrap(),
-            Duration::seconds(2_592_000)
-        );
-        assert_eq!(
-            parse_relative_time("1 month and 2 weeks").unwrap(),
-            Duration::seconds(3_801_600)
-        );
-        assert_eq!(
-            parse_relative_time("1 month, 2 weeks").unwrap(),
-            Duration::seconds(3_801_600)
-        );
-        assert_eq!(
-            parse_relative_time("1 months 2 weeks").unwrap(),
-            Duration::seconds(3_801_600)
-        );
-        assert_eq!(
-            parse_relative_time("1 month and 2 weeks ago").unwrap(),
-            Duration::seconds(-3_801_600)
-        );
-        assert_eq!(
-            parse_relative_time("2 months").unwrap(),
-            Duration::seconds(5_184_000)
-        );
-        assert_eq!(
-            parse_relative_time("month").unwrap(),
-            Duration::seconds(2_592_000)
-        );
-
-        assert_eq!(
-            parse_relative_time("1 fortnight").unwrap(),
-            Duration::seconds(1_209_600)
-        );
-        assert_eq!(
-            parse_relative_time("3 fortnights").unwrap(),
-            Duration::seconds(3_628_800)
-        );
-        assert_eq!(
-            parse_relative_time("fortnight").unwrap(),
-            Duration::seconds(1_209_600)
-        );
-
-        assert_eq!(
-            parse_relative_time("1 week").unwrap(),
-            Duration::seconds(604_800)
-        );
-        assert_eq!(
-            parse_relative_time("1 week 3 days").unwrap(),
-            Duration::seconds(864_000)
-        );
-        assert_eq!(
-            parse_relative_time("1 week 3 days ago").unwrap(),
-            Duration::seconds(-864_000)
-        );
-        assert_eq!(
-            parse_relative_time("-2 weeks").unwrap(),
-            Duration::seconds(-1_209_600)
-        );
-        assert_eq!(
-            parse_relative_time("2 weeks ago").unwrap(),
-            Duration::seconds(-1_209_600)
-        );
-        assert_eq!(
-            parse_relative_time("week").unwrap(),
-            Duration::seconds(604_800)
-        );
-
-        assert_eq!(
-            parse_relative_time("1 day").unwrap(),
-            Duration::seconds(86_400)
-        );
-        assert_eq!(
-            parse_relative_time("2 days ago").unwrap(),
-            Duration::seconds(-172_800)
-        );
-        assert_eq!(
-            parse_relative_time("-2 days").unwrap(),
-            Duration::seconds(-172_800)
-        );
-        assert_eq!(
-            parse_relative_time("day").unwrap(),
-            Duration::seconds(86_400)
-        );
-
-        assert_eq!(
-            parse_relative_time("1 hour").unwrap(),
-            Duration::seconds(3_600)
-        );
-        assert_eq!(
-            parse_relative_time("1 h").unwrap(),
-            Duration::seconds(3_600)
-        );
-        assert_eq!(
-            parse_relative_time("1 hour ago").unwrap(),
-            Duration::seconds(-3_600)
-        );
-        assert_eq!(
-            parse_relative_time("-2 hours").unwrap(),
-            Duration::seconds(-7_200)
-        );
-        assert_eq!(
-            parse_relative_time("hour").unwrap(),
-            Duration::seconds(3_600)
-        );
-
-        assert_eq!(
-            parse_relative_time("1 minute").unwrap(),
-            Duration::seconds(60)
-        );
-        assert_eq!(parse_relative_time("1 min").unwrap(), Duration::seconds(60));
-        assert_eq!(
-            parse_relative_time("2 minutes").unwrap(),
-            Duration::seconds(120)
-        );
-        assert_eq!(
-            parse_relative_time("2 mins").unwrap(),
-            Duration::seconds(120)
-        );
-        assert_eq!(parse_relative_time("2m").unwrap(), Duration::seconds(120));
-        assert_eq!(parse_relative_time("min").unwrap(), Duration::seconds(60));
-
-        assert_eq!(
-            parse_relative_time("1 second").unwrap(),
-            Duration::seconds(1)
-        );
-        assert_eq!(parse_relative_time("1 s").unwrap(), Duration::seconds(1));
-        assert_eq!(
-            parse_relative_time("2 seconds").unwrap(),
-            Duration::seconds(2)
-        );
-        assert_eq!(parse_relative_time("2 secs").unwrap(), Duration::seconds(2));
-        assert_eq!(parse_relative_time("2 sec").unwrap(), Duration::seconds(2));
-        assert_eq!(parse_relative_time("sec").unwrap(), Duration::seconds(1));
-
-        assert_eq!(parse_relative_time("now").unwrap(), Duration::seconds(0));
-        assert_eq!(parse_relative_time("today").unwrap(), Duration::seconds(0));
-
-        assert_eq!(
-            parse_relative_time("1 year 2 months 4 weeks 3 days and 2 seconds").unwrap(),
-            Duration::seconds(39_398_402)
-        );
-        assert_eq!(
-            parse_relative_time("1 year 2 months 4 weeks 3 days and 2 seconds ago").unwrap(),
-            Duration::seconds(-39_398_402)
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_display_parse_duration_error_through_parse_relative_time() {
-        let invalid_input = "9223372036854775807 seconds and 1 second";
-        let _ = parse_relative_time(invalid_input).unwrap();
-    }
-
-    #[test]
-    fn test_display_should_fail() {
-        let invalid_input = "Thu Jan 01 12:34:00 2015";
-        let error = parse_relative_time(invalid_input).unwrap_err();
-
-        assert_eq!(
-            format!("{error}"),
-            "Invalid input string: cannot be parsed as a relative time"
-        );
-    }
-
-    #[test]
-    fn test_parse_relative_time_at_date_day() {
-        let today = Utc::now().date_naive();
-        let yesterday = today - Duration::days(1);
-        assert_eq!(
-            parse_relative_time_at_date(yesterday, "2 days").unwrap(),
-            Duration::days(1)
-        );
-    }
-
-    #[test]
-    fn test_invalid_input_at_date_relative() {
-        let today = Utc::now().date_naive();
-        let result = parse_relative_time_at_date(today, "foobar");
-        println!("{result:?}");
-        assert_eq!(result, Err(ParseDateTimeError::InvalidInput));
-
-        let result = parse_relative_time_at_date(today, "invalid 1r");
-        assert_eq!(result, Err(ParseDateTimeError::InvalidInput));
+        let date0 = DateTime::parse_from_str("2022 May 15 00:00:00.0 +0000", format).unwrap();
+        for modifier in input.into_iter() {
+            assert!(dt_from_relative(modifier, date0).is_err());
+        }
     }
 }


### PR DESCRIPTION
My apologies for the long delay. This PR adds date modification parsing such as `2022-05-15 +1 month`. This PR added the core functionality to `parse_relative_time` and integrated the functionality to `lib.rs`, specifically `pub fn parse_datetime`.

This did require moving things around. Specifically `pub fn parse_datetime` is now solely responsible for parsing date strings instead of passing off parsing to `pub fn parse_datetime_at_date` which is what it did before. The reason for this change is that `parse_datetime_at_date` was awkward.

Currently `pub fn parse_datetime` takes a date string and passes of the input to `pub fn parse_datetime_at_date` with an additional `Local::now()` argument and does the actual parsing there. This is awkward because according to its current docs `parse_datetime_at_date` takes strings such as `+3 days` and performs the modification on the given input `DateTime`. Allegedly doing no date string parsing. But it did do parsing. In fact, it did mostly parsing and only really performed its documentation described behavior after trying parsing first. Almost like it was an after thought and not its primary responsibility. 90% of the behavior was ignoring its `DateTime<Local>` input because most of the time it was there just in case it was needed. This made integrating my new modification parsing awkward. I hope that all made sense.

TLDR I moved the parsing out of `parse_datetime_at_date` and into `parse_datetime` to make its function consistent with its documentation. Now `parse_datetime_at_date` still parse strings such as `+3 days` and only that. 

The rest is what should be as expected. This PR is to eventually address [3505](https://github.com/uutils/coreutils/issues/3505) and is a more robust PR to my first attempt [here](https://github.com/uutils/coreutils/pull/5476).

Thank you for considering my PR. This was a big one so I fully anticipate a bit of feedback and requests for tweaks. Anyway, Happy New Year!