### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ assert_eq!(
 );
 ```
 
-For DateTime parsing, import the `parse_datetime` module:
+For DateTime parsing, import the `parse_datetime` function:
 
 ```rs
-use parse_datetime::parse_datetime::from_str;
+use parse_datetime::parse_datetime;
 use chrono::{Local, TimeZone};
 
-let dt = from_str("2021-02-14 06:37:47");
+let dt = parse_datetime("2021-02-14 06:37:47");
 assert_eq!(dt.unwrap(), Local.with_ymd_and_hms(2021, 2, 14, 6, 37, 47).unwrap());
 ```
 


### PR DESCRIPTION
The README seems to reference a `from_str` function that doesn't exist any more.  The following code doesn't work for me:

```
parse_datetime::parse_datetime::from_str(tstr)
```

returning 

```
failed to resolve: expected type, found function `parse_datetime` in `parse_datetime`
```

If instead I change it to 

```
parse_datetime::parse_datetime(tstr)
```

it works fine.