### PR TITLE
support for parsing date string with only time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::fmt::{self, Display};
 mod parse_relative_time;
 mod parse_timestamp;
 
+mod parse_time_only_str;
 mod parse_weekday;
 
 use chrono::{
@@ -235,6 +236,11 @@ pub fn parse_datetime_at_date<S: AsRef<str> + Clone>(
         if let Some(date_time) = current_time.checked_add_signed(relative_time) {
             return Ok(date_time);
         }
+    }
+
+    // parse time only dates
+    if let Some(date_time) = parse_time_only_str::parse_time_only(date, s.as_ref()) {
+        return Ok(date_time);
     }
 
     // Default parse and failure

--- a/src/parse_time_only_str.rs
+++ b/src/parse_time_only_str.rs
@@ -1,0 +1,120 @@
+use chrono::{DateTime, FixedOffset, Local, NaiveTime, TimeZone};
+use regex::Regex;
+
+mod time_only_formats {
+    pub const HH_MM: &str = "%R";
+    pub const HH_MM_SS: &str = "%T";
+    pub const TWELVEHOUR: &str = "%r";
+}
+
+pub(crate) fn parse_time_only(date: DateTime<Local>, s: &str) -> Option<DateTime<FixedOffset>> {
+    let re =
+        Regex::new(r"^(?<time>.*?)(?:(?<sign>\+|-)(?<h>[0-9]{1,2}):?(?<m>[0-9]{0,2}))?$").unwrap();
+    let captures = re.captures(s)?;
+
+    let parsed_offset = match captures.name("h") {
+        Some(hours) if !(hours.as_str().is_empty()) => {
+            let mut offset_in_sec = hours.as_str().parse::<i32>().unwrap() * 3600;
+            match captures.name("m") {
+                Some(minutes) if !(minutes.as_str().is_empty()) => {
+                    offset_in_sec += minutes.as_str().parse::<i32>().unwrap() * 60;
+                }
+                _ => (),
+            };
+            offset_in_sec *= if &captures["sign"] == "-" { -1 } else { 1 };
+            FixedOffset::east_opt(offset_in_sec)
+        }
+        _ => None,
+    };
+
+    for fmt in [
+        time_only_formats::HH_MM,
+        time_only_formats::HH_MM_SS,
+        time_only_formats::TWELVEHOUR,
+    ] {
+        if let Ok(parsed) = NaiveTime::parse_from_str(captures["time"].trim(), fmt) {
+            let parsed_dt = date.date_naive().and_time(parsed);
+            let offset = match parsed_offset {
+                Some(offset) => offset,
+                None => *date.offset(),
+            };
+            return offset.from_local_datetime(&parsed_dt).single();
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse_time_only_str::parse_time_only;
+    use chrono::{DateTime, Local, TimeZone};
+    use std::env;
+
+    fn get_test_date() -> DateTime<Local> {
+        Local.with_ymd_and_hms(2024, 03, 03, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn test_time_only() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "21:04")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709499840)
+    }
+
+    #[test]
+    fn test_time_with_offset() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "21:04 +0530")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709480040);
+    }
+
+    #[test]
+    fn test_time_with_hour_only_offset() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "22:04 +01")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709499840);
+    }
+
+    #[test]
+    fn test_time_with_hour_only_neg_offset() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "17:04 -04")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709499840);
+    }
+
+    #[test]
+    fn test_time_with_seconds() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "21:04:30")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709499870)
+    }
+
+    #[test]
+    fn test_time_with_seconds_with_offset() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "21:04:30 +0530")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709480070)
+    }
+
+    #[test]
+    fn test_twelve_hour_time() {
+        env::set_var("TZ", "UTC");
+        let parsed_time = parse_time_only(get_test_date(), "9:04:00 PM")
+            .unwrap()
+            .timestamp();
+        assert_eq!(parsed_time, 1709499840)
+    }
+}


### PR DESCRIPTION
Hi, i was trying to fix the `date-sec` test case in [gnu test coverage](https://uutils.github.io/coreutils/book/test_coverage.html) in coreutils-date and i figured if i could make parse_datetime to take strings with only time and offset it would fix the issue and from the code I figured you guys are already working on a parser but as a temporary fix i wrote the following code to deal with the issue. Please do let me know if this not the way it was supposed to be implemented or any kind of change at all. Thank you 