### PR TITLE
clippy: fix warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,7 @@ mod tests {
         #[test]
         fn test_weekday() {
             // add some constant hours and minutes and seconds to check its reset
-            let date = Local.with_ymd_and_hms(2023, 02, 28, 10, 12, 3).unwrap();
+            let date = Local.with_ymd_and_hms(2023, 2, 28, 10, 12, 3).unwrap();
 
             // 2023-2-28 is tuesday
             assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ mod tests {
             ];
 
             for relative_time in relative_times {
-                assert_eq!(parse_datetime(relative_time).is_ok(), true);
+                assert!(parse_datetime(relative_time).is_ok());
             }
         }
     }

--- a/src/parse_time_only_str.rs
+++ b/src/parse_time_only_str.rs
@@ -52,7 +52,7 @@ mod tests {
     use std::env;
 
     fn get_test_date() -> DateTime<Local> {
-        Local.with_ymd_and_hms(2024, 03, 03, 0, 0, 0).unwrap()
+        Local.with_ymd_and_hms(2024, 3, 3, 0, 0, 0).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes clippy warnings from the [zero_prefixed_literal](https://rust-lang.github.io/rust-clippy/master/index.html#/zero_prefixed_literal) and [bool_assert_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#/bool_assert_comparison) lints.