### PR TITLE
ci: use `clippy --all-targets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings
 
   coverage:
     name: Code Coverage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,7 +476,7 @@ mod tests {
         #[test]
         fn test_time_only() {
             env::set_var("TZ", "UTC");
-            let test_date = Local.with_ymd_and_hms(2024, 03, 03, 0, 0, 0).unwrap();
+            let test_date = Local.with_ymd_and_hms(2024, 3, 3, 0, 0, 0).unwrap();
             let parsed_time = parse_datetime_at_date(test_date, "9:04:30 PM +0530")
                 .unwrap()
                 .timestamp();


### PR DESCRIPTION
This PR adds `--all-targets` to the clippy job in the CI and fixes two warnings from the [zero_prefixed_literal](https://rust-lang.github.io/rust-clippy/master/index.html#/zero_prefixed_literal) lint.