### PR TITLE
readme: bump version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-parse_datetime = "0.5.0"
+parse_datetime = "0.6.0"
 ```
 
 Then, import the crate and use the `parse_datetime_at_date` function:


### PR DESCRIPTION
I forgot to bump the version info in the readme when I did the release.