### PR TITLE
Bump `nom` & adapt to API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,19 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 [dependencies]
 regex = "1.10.4"
 chrono = { version="0.4.38", default-features=false, features=["std", "alloc", "clock"] }
-nom = "7.1.3"
+nom = "8.0.0"

--- a/src/parse_timestamp.rs
+++ b/src/parse_timestamp.rs
@@ -10,8 +10,7 @@ use nom::character::complete::{char, digit1};
 use nom::combinator::all_consuming;
 use nom::multi::fold_many0;
 use nom::sequence::preceded;
-use nom::sequence::tuple;
-use nom::{self, IResult};
+use nom::{self, IResult, Parser};
 
 #[derive(Debug, PartialEq)]
 pub enum ParseTimestampError {
@@ -55,7 +54,7 @@ pub(crate) fn parse_timestamp(s: &str) -> Result<i64, ParseTimestampError> {
 
     let res: IResult<&str, (char, &str)> = all_consuming(preceded(
         char('@'),
-        tuple((
+        (
             // Note: to stay compatible with gnu date this code allows
             // multiple + and - and only considers the last one
             fold_many0(
@@ -67,8 +66,9 @@ pub(crate) fn parse_timestamp(s: &str) -> Result<i64, ParseTimestampError> {
                 |_, c| c,
             ),
             digit1,
-        )),
-    ))(s);
+        ),
+    ))
+    .parse(s);
 
     let (_, (sign, number_str)) = res?;
 

--- a/src/parse_weekday.rs
+++ b/src/parse_weekday.rs
@@ -4,7 +4,7 @@ use chrono::Weekday;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::value;
-use nom::{self, IResult};
+use nom::{self, IResult, Parser};
 
 // Helper macro to simplify tag matching
 macro_rules! tag_match {
@@ -25,7 +25,8 @@ pub(crate) fn parse_weekday(s: &str) -> Option<Weekday> {
         tag_match!(Weekday::Fri, "friday", "fri"),
         tag_match!(Weekday::Sat, "saturday", "sat"),
         tag_match!(Weekday::Sun, "sunday", "sun"),
-    )))(s);
+    )))
+    .parse(s);
 
     match parse_result {
         Ok((_, weekday)) => Some(weekday),


### PR DESCRIPTION
This PR bumps `nom` from `7.1.3` to `8.0.0` and adapts the code to API changes in `nom`.