### PR TITLE
Parse reference datetime and timedelta from the same string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ mod format {
     pub const YYYYMMDDHHMMSS_HYPHENATED_OFFSET: &str = "%Y-%m-%d %H:%M:%S %#z";
     pub const YYYYMMDDHHMMSS_HYPHENATED_ZULU: &str = "%Y-%m-%d %H:%M:%SZ";
     pub const YYYYMMDDHHMMSS_T_SEP_HYPHENATED_OFFSET: &str = "%Y-%m-%dT%H:%M:%S%#z";
+    pub const YYYYMMDDHHMMSS_T_SEP_HYPHENATED_ZULU: &str = "%Y-%m-%dT%H:%M:%SZ";
     pub const YYYYMMDDHHMMSS_T_SEP_HYPHENATED_SPACE_OFFSET: &str = "%Y-%m-%dT%H:%M:%S %#z";
     pub const YYYYMMDDHHMMS_T_SEP: &str = "%Y-%m-%dT%H:%M:%S";
     pub const UTC_OFFSET: &str = "UTC%#z";
@@ -88,7 +89,7 @@ mod format {
 
     /// Whether the pattern ends in the character `Z`.
     pub(crate) fn is_zulu(pattern: &str) -> bool {
-        pattern == YYYYMMDDHHMMSS_HYPHENATED_ZULU
+        pattern == YYYYMMDDHHMMSS_HYPHENATED_ZULU || pattern == YYYYMMDDHHMMSS_T_SEP_HYPHENATED_ZULU
     }
 
     /// Patterns for datetimes with timezones.
@@ -113,10 +114,11 @@ mod format {
     /// Patterns for datetimes without timezones.
     ///
     /// These are in decreasing order of length.
-    pub(crate) const PATTERNS_NO_TZ: [(&str, usize); 8] = [
+    pub(crate) const PATTERNS_NO_TZ: [(&str, usize); 9] = [
         (YYYYMMDDHHMMSS, 29),
         (POSIX_LOCALE, 24),
         (YYYYMMDDHHMMSS_HYPHENATED_ZULU, 20),
+        (YYYYMMDDHHMMSS_T_SEP_HYPHENATED_ZULU, 20),
         (YYYYMMDDHHMMS_T_SEP, 19),
         (YYYYMMDDHHMMS, 19),
         (YYYY_MM_DD_HH_MM, 16),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ mod format {
 
     /// Whether the pattern ends in the character `Z`.
     pub(crate) fn is_zulu(pattern: &str) -> bool {
-        pattern == YYYYMMDDHHMMSS_HYPHENATED_ZULU || pattern == YYYYMMDDHHMMSS_T_SEP_HYPHENATED_ZULU
+        pattern.ends_with('Z')
     }
 
     /// Patterns for datetimes with timezones.


### PR DESCRIPTION
Change the `parse_datetime()` function so that it parses both a
reference date and a time delta from one string. The new implementation
attempts to parse the datetime from the longest possible prefix of the
string. The remainder of the string is parsed as the time delta. This
allows us to parse more combinations of reference dates and time deltas
more easily.

Fixes #104