### PR TITLE
Make tests of adding months more resilient

### DIFF
--- a/src/parse_relative_time.rs
+++ b/src/parse_relative_time.rs
@@ -319,10 +319,12 @@ mod tests {
 
     #[test]
     fn test_months() {
+        use crate::parse_relative_time::add_months;
+
         let now = Utc::now();
         assert_eq!(
             parse_relative_time_at_date(now, "1 month").unwrap(),
-            now.checked_add_months(Months::new(1)).unwrap()
+            add_months(now, 1, false).unwrap(),
         );
         assert_eq!(
             parse_relative_time_at_date(now, "this month").unwrap(),
@@ -330,14 +332,14 @@ mod tests {
         );
         assert_eq!(
             parse_relative_time_at_date(now, "1 month and 2 weeks").unwrap(),
-            now.checked_add_months(Months::new(1))
+            add_months(now, 1, false)
                 .unwrap()
                 .checked_add_days(Days::new(14))
                 .unwrap()
         );
         assert_eq!(
             parse_relative_time_at_date(now, "1 month and 2 weeks ago").unwrap(),
-            now.checked_sub_months(Months::new(1))
+            add_months(now, 1, true)
                 .unwrap()
                 .checked_sub_days(Days::new(14))
                 .unwrap()
@@ -348,7 +350,7 @@ mod tests {
         );
         assert_eq!(
             parse_relative_time_at_date(now, "month").unwrap(),
-            now.checked_add_months(Months::new(1)).unwrap()
+            add_months(now, 1, false).unwrap(),
         );
     }
 
@@ -562,6 +564,8 @@ mod tests {
 
     #[test]
     fn test_duration_parsing() {
+        use crate::parse_relative_time::add_months;
+
         let now = Utc::now();
         assert_eq!(
             parse_relative_time_at_date(now, "1 year").unwrap(),
@@ -582,25 +586,25 @@ mod tests {
 
         assert_eq!(
             parse_relative_time_at_date(now, "1 month").unwrap(),
-            now.checked_add_months(Months::new(1)).unwrap()
+            add_months(now, 1, false).unwrap(),
         );
         assert_eq!(
             parse_relative_time_at_date(now, "1 month and 2 weeks").unwrap(),
-            now.checked_add_months(Months::new(1))
+            add_months(now, 1, false)
                 .unwrap()
                 .checked_add_days(Days::new(14))
                 .unwrap()
         );
         assert_eq!(
             parse_relative_time_at_date(now, "1 month, 2 weeks").unwrap(),
-            now.checked_add_months(Months::new(1))
+            add_months(now, 1, false)
                 .unwrap()
                 .checked_add_days(Days::new(14))
                 .unwrap()
         );
         assert_eq!(
             parse_relative_time_at_date(now, "1 months 2 weeks").unwrap(),
-            now.checked_add_months(Months::new(1))
+            add_months(now, 1, false)
                 .unwrap()
                 .checked_add_days(Days::new(14))
                 .unwrap()
@@ -618,7 +622,7 @@ mod tests {
         );
         assert_eq!(
             parse_relative_time_at_date(now, "month").unwrap(),
-            now.checked_add_months(Months::new(1)).unwrap()
+            add_months(now, 1, false).unwrap(),
         );
 
         assert_eq!(


### PR DESCRIPTION
Protect against a situation where adding one month to the current day would cause an overflow in the next month in some unit tests of `parse_relative_time`. For example, adding one month to March 31 should overflow to May 1 because April only has 30 days. This is a difference in the behavior we want for our library compared with the behavior of `chrono`.

This change was extracted from pull request #110.