### PR TITLE
Parse relative weekdays like "next monday"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parse_datetime"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parse_datetime"
 description = "parsing human-readable time strings and converting them to a DateTime"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/uutils/parse_datetime"


### PR DESCRIPTION
Fixes https://github.com/uutils/parse_datetime/issues/127 and https://github.com/uutils/coreutils/issues/7662. Enables GNU test `tests/date/date-next-dow.pl` to pass:
```
$ bash util/run-gnu-test.sh tests/date/date-next-dow.pl
...
PASS: tests/date/date-next-dow.pl
============================================================================
Testsuite summary for GNU coreutils 9.6-dirty
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
Note, this also allows some formats that GNU date doesn't accept, but I think they're reasonable:
```
$ date +"%a %F"
Mon 2025-04-21

$ set d "1 monday ago" ; date -d $d +"%a %F" ; cargo run -q date -d $d +"%a %F"
date: invalid date ‘1 monday ago’
Mon 2025-04-14

$ set d "-1 monday" ; date -d $d +"%a %F" ; cargo run -q date -d $d +"%a %F"
date: invalid date ‘-1 monday’
Mon 2025-04-14

$ set d "+1 monday" ; date -d $d +"%a %F" ; cargo run -q date -d $d +"%a %F"
date: invalid date ‘+1 monday’
Mon 2025-04-28

# Strangely enough, GNU does recognize this format:
$ set d "1 monday" ; date -d $d +"%a %F" ; cargo run -q date -d $d +"%a %F"
Mon 2025-04-28
Mon 2025-04-28
```