### PR TITLE
formalize grammar of timestamp strings and use nom to parse them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,12 @@ mod parse_time_only_str;
 mod parse_weekday;
 
 use chrono::{
-    DateTime, Datelike, Duration, FixedOffset, Local, LocalResult, MappedLocalTime, NaiveDate,
-    NaiveDateTime, TimeZone, Timelike,
+    DateTime, FixedOffset, Local, LocalResult, MappedLocalTime, NaiveDate, NaiveDateTime, TimeZone,
 };
 
 use parse_relative_time::parse_relative_time_at_date;
 use parse_timestamp::parse_timestamp;
+use parse_weekday::parse_weekday_at_date;
 
 #[derive(Debug, PartialEq)]
 pub enum ParseDateTimeError {
@@ -302,23 +302,8 @@ where
     }
 
     // parse weekday
-    if let Some(weekday) = parse_weekday::parse_weekday(s.as_ref()) {
-        let mut beginning_of_day = date
-            .with_hour(0)
-            .unwrap()
-            .with_minute(0)
-            .unwrap()
-            .with_second(0)
-            .unwrap()
-            .with_nanosecond(0)
-            .unwrap();
-
-        while beginning_of_day.weekday() != weekday {
-            beginning_of_day += Duration::days(1);
-        }
-
-        let dt = DateTime::<FixedOffset>::from(beginning_of_day);
-
+    if let Ok(dt) = parse_weekday_at_date(date, s.as_ref()) {
+        let dt = DateTime::<FixedOffset>::from(dt);
         return Some((dt, s.as_ref().len()));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use regex::Regex;
 use std::error::Error;
 use std::fmt::{self, Display};
 
+pub(crate) mod parse;
+
 // Expose parse_datetime
 mod parse_relative_time;
 mod parse_timestamp;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,10 +1,12 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use relative_time::relative_times;
+use timestamp::timestamp;
 use weekday::weekday;
 
 mod primitive;
 mod relative_time;
+mod timestamp;
 mod weekday;
 
 // TODO: more specific errors?
@@ -19,6 +21,13 @@ pub(crate) use weekday::WeekdayItem;
 pub(crate) fn parse_relative_times(input: &str) -> Result<Vec<RelativeTime>, ParseError> {
     relative_times(input)
         .map(|(_, times)| times)
+        .map_err(|_| ParseError)
+}
+
+/// Parses a string of timestamp into a `f64` value (the seconds since epoch).
+pub(crate) fn parse_timestamp(input: &str) -> Result<f64, ParseError> {
+    timestamp(input)
+        .map(|(_, timestamp)| timestamp)
         .map_err(|_| ParseError)
 }
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,8 +1,11 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use relative_time::relative_times;
+use weekday::weekday;
 
+mod primitive;
 mod relative_time;
+mod weekday;
 
 // TODO: more specific errors?
 #[derive(Debug)]
@@ -10,10 +13,29 @@ pub(crate) struct ParseError;
 
 pub(crate) use relative_time::RelativeTime;
 pub(crate) use relative_time::TimeUnit;
+pub(crate) use weekday::WeekdayItem;
 
 /// Parses a string of relative times into a vector of `RelativeTime` structs.
 pub(crate) fn parse_relative_times(input: &str) -> Result<Vec<RelativeTime>, ParseError> {
     relative_times(input)
         .map(|(_, times)| times)
         .map_err(|_| ParseError)
+}
+
+/// Parses a string of weekday into a `WeekdayItem` struct.
+pub(crate) fn parse_weekday(input: &str) -> Result<WeekdayItem, ParseError> {
+    weekday(input)
+        .map(|(_, weekday_item)| weekday_item)
+        .map_err(|_| ParseError)
+}
+
+/// Finds a value in a list of pairs by its key.
+fn find_in_pairs<T: Clone>(pairs: &[(&str, T)], key: &str) -> Option<T> {
+    pairs.iter().find_map(|(k, v)| {
+        if k.eq_ignore_ascii_case(key) {
+            Some(v.clone())
+        } else {
+            None
+        }
+    })
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,0 +1,19 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+use relative_time::relative_times;
+
+mod relative_time;
+
+// TODO: more specific errors?
+#[derive(Debug)]
+pub(crate) struct ParseError;
+
+pub(crate) use relative_time::RelativeTime;
+pub(crate) use relative_time::TimeUnit;
+
+/// Parses a string of relative times into a vector of `RelativeTime` structs.
+pub(crate) fn parse_relative_times(input: &str) -> Result<Vec<RelativeTime>, ParseError> {
+    relative_times(input)
+        .map(|(_, times)| times)
+        .map_err(|_| ParseError)
+}

--- a/src/parse/primitive.rs
+++ b/src/parse/primitive.rs
@@ -69,7 +69,7 @@ pub(super) fn integer(input: &str) -> IResult<&str, i64> {
 /// sign characters and whitespace characters. All but the last sign character
 /// is ignored, and the last sign character is returned as the result. This
 /// quirky behavior is to stay consistent with GNU date.
-fn sign(input: &str) -> IResult<&str, char> {
+pub(super) fn sign(input: &str) -> IResult<&str, char> {
     fold_many1(
         terminated(one_of("+-"), multispace0),
         || '+',

--- a/src/parse/primitive.rs
+++ b/src/parse/primitive.rs
@@ -1,0 +1,144 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Module to parser relative time strings.
+//!
+//! Grammar definition:
+//!
+//! ```ebnf
+//! ordinal = "last" | "this" | "next"
+//!         | "first" | "third" | "fourth" | "fifth"
+//!         | "sixth" | "seventh" | "eighth" | "ninth"
+//!         | "tenth" | "eleventh" | "twelfth" ;
+//!
+//! integer = [ sign ] , digit , { digit } ;
+//!
+//! sign = { ("+" | "-") , { whitespace } } ;
+//!
+//! digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+//! ```
+
+use nom::{
+    bytes::complete::take_while1,
+    character::complete::{digit1, multispace0, one_of},
+    combinator::{map_res, opt},
+    multi::fold_many1,
+    sequence::terminated,
+    IResult, Parser,
+};
+
+use super::find_in_pairs;
+
+const ORDINALS: &[(&str, i64)] = &[
+    ("last", -1),
+    ("this", 0),
+    ("next", 1),
+    ("first", 1),
+    // Unfortunately we can't use "second" as ordinal, the keyword is overloaded
+    ("third", 3),
+    ("fourth", 4),
+    ("fifth", 5),
+    ("sixth", 6),
+    ("seventh", 7),
+    ("eighth", 8),
+    ("ninth", 9),
+    ("tenth", 10),
+    ("eleventh", 11),
+    ("twelfth", 12),
+];
+
+pub(super) fn ordinal(input: &str) -> IResult<&str, i64> {
+    map_res(take_while1(|c: char| c.is_alphabetic()), |s: &str| {
+        find_in_pairs(ORDINALS, s).ok_or("unknown ordinal")
+    })
+    .parse(input)
+}
+
+pub(super) fn integer(input: &str) -> IResult<&str, i64> {
+    let (rest, sign) = opt(sign).parse(input)?;
+    let (rest, num) = map_res(digit1, str::parse::<i64>).parse(rest)?;
+    if sign == Some('-') {
+        Ok((rest, -num))
+    } else {
+        Ok((rest, num))
+    }
+}
+
+/// Parses a sign (either + or -) from the input string. The input string must
+/// start with a sign character followed by arbitrary number of interleaving
+/// sign characters and whitespace characters. All but the last sign character
+/// is ignored, and the last sign character is returned as the result. This
+/// quirky behavior is to stay consistent with GNU date.
+fn sign(input: &str) -> IResult<&str, char> {
+    fold_many1(
+        terminated(one_of("+-"), multispace0),
+        || '+',
+        |acc, c| if "+-".contains(c) { c } else { acc },
+    )
+    .parse(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ordinal() {
+        assert!(ordinal("").is_err());
+        assert!(ordinal("invalid").is_err());
+        assert!(ordinal(" last").is_err());
+
+        assert_eq!(ordinal("last"), Ok(("", -1)));
+        assert_eq!(ordinal("this"), Ok(("", 0)));
+        assert_eq!(ordinal("next"), Ok(("", 1)));
+        assert_eq!(ordinal("first"), Ok(("", 1)));
+        assert_eq!(ordinal("third"), Ok(("", 3)));
+        assert_eq!(ordinal("fourth"), Ok(("", 4)));
+        assert_eq!(ordinal("fifth"), Ok(("", 5)));
+        assert_eq!(ordinal("sixth"), Ok(("", 6)));
+        assert_eq!(ordinal("seventh"), Ok(("", 7)));
+        assert_eq!(ordinal("eighth"), Ok(("", 8)));
+        assert_eq!(ordinal("ninth"), Ok(("", 9)));
+        assert_eq!(ordinal("tenth"), Ok(("", 10)));
+        assert_eq!(ordinal("eleventh"), Ok(("", 11)));
+        assert_eq!(ordinal("twelfth"), Ok(("", 12)));
+
+        // Boundary
+        assert_eq!(ordinal("last123"), Ok(("123", -1)));
+        assert_eq!(ordinal("last abc"), Ok((" abc", -1)));
+        assert!(ordinal("lastabc").is_err());
+
+        // Case insensitive
+        assert_eq!(ordinal("THIS"), Ok(("", 0)));
+        assert_eq!(ordinal("This"), Ok(("", 0)));
+    }
+
+    #[test]
+    fn test_integer() {
+        assert!(integer("").is_err());
+        assert!(integer("invalid").is_err());
+        assert!(integer(" 123").is_err());
+
+        assert_eq!(integer("123"), Ok(("", 123)));
+        assert_eq!(integer("+123"), Ok(("", 123)));
+        assert_eq!(integer("- 123"), Ok(("", -123)));
+
+        // Boundary
+        assert_eq!(integer("- 123abc"), Ok(("abc", -123)));
+        assert_eq!(integer("- +- 123abc"), Ok(("abc", -123)));
+    }
+
+    #[test]
+    fn test_sign() {
+        assert!(sign("").is_err());
+        assert!(sign("invalid").is_err());
+        assert!(sign(" +").is_err());
+
+        assert_eq!(sign("+"), Ok(("", '+')));
+        assert_eq!(sign("-"), Ok(("", '-')));
+        assert_eq!(sign("- + - "), Ok(("", '-')));
+
+        // Boundary
+        assert_eq!(sign("- + - abc"), Ok(("abc", '-')));
+    }
+}

--- a/src/parse/relative_time.rs
+++ b/src/parse/relative_time.rs
@@ -1,0 +1,620 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Module to parser relative time strings.
+//!
+//! Grammar definition:
+//!
+//! ```ebnf
+//! relative_times = relative_time , { ("," | "and") , relative_time } ;
+//!
+//! relative_time = displacement | day_shift ;
+//!
+//! displacement = (integer | ordinal) unit [ "ago" ] ;
+//!
+//! day_shift = "now" | "today" | "tomorrow" | "yesterday" ;
+//!
+//! unit = "seconds" | "second" | "secs" | "sec" | "s"
+//!      | "minutes" | "minute" | "mins" | "min" | "m"
+//!      | "hours" | "hour" | "h"
+//!      | "days" | "day"
+//!      | "weeks" | "week"
+//!      | "fortnights" | "fortnight"
+//!      | "months" | "month"
+//!      | "years" | "year" ;
+//!
+//! ordinal = "last" | "this" | "next"
+//!         | "first" | "third" | "fourth" | "fifth"
+//!         | "sixth" | "seventh" | "eighth" | "ninth"
+//!         | "tenth" | "eleventh" | "twelfth" ;
+//!
+//! integer = [ sign ] , digit , { digit } ;
+//!
+//! sign = { ("+" | "-") { whitespace } } ;
+//!
+//! digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+//! ```
+
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, tag_no_case, take_while1},
+    character::complete::{digit1, multispace0, multispace1, one_of},
+    combinator::{all_consuming, map_res, opt},
+    multi::{fold_many1, separated_list0},
+    sequence::{preceded, terminated},
+    IResult, Parser,
+};
+
+const TIME_UNITS: &[(&str, TimeUnit)] = &[
+    ("seconds", TimeUnit::Second),
+    ("second", TimeUnit::Second),
+    ("secs", TimeUnit::Second),
+    ("sec", TimeUnit::Second),
+    ("s", TimeUnit::Second),
+    ("minutes", TimeUnit::Minute),
+    ("minute", TimeUnit::Minute),
+    ("mins", TimeUnit::Minute),
+    ("min", TimeUnit::Minute),
+    ("m", TimeUnit::Minute),
+    ("hours", TimeUnit::Hour),
+    ("hour", TimeUnit::Hour),
+    ("h", TimeUnit::Hour),
+    ("days", TimeUnit::Day),
+    ("day", TimeUnit::Day),
+    ("weeks", TimeUnit::Week),
+    ("week", TimeUnit::Week),
+    ("fortnights", TimeUnit::Fortnight),
+    ("fortnight", TimeUnit::Fortnight),
+    ("months", TimeUnit::Month),
+    ("month", TimeUnit::Month),
+    ("years", TimeUnit::Year),
+    ("year", TimeUnit::Year),
+];
+
+const DAY_SHIFTS: &[(&str, RelativeTime)] = &[
+    ("now", RelativeTime::Now),
+    ("today", RelativeTime::Today),
+    ("tomorrow", RelativeTime::Tomorrow),
+    ("yesterday", RelativeTime::Yesterday),
+];
+
+const ORDINALS: &[(&str, i64)] = &[
+    ("last", -1),
+    ("this", 0),
+    ("next", 1),
+    ("first", 1),
+    // Unfortunately we can't use "second" as ordinal, the keyword is overloaded
+    ("third", 3),
+    ("fourth", 4),
+    ("fifth", 5),
+    ("sixth", 6),
+    ("seventh", 7),
+    ("eighth", 8),
+    ("ninth", 9),
+    ("tenth", 10),
+    ("eleventh", 11),
+    ("twelfth", 12),
+];
+
+/// The `TimeUnit` enum represents the different time units that can be used in
+/// relative time parsing.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum TimeUnit {
+    Second,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Fortnight,
+    Month,
+    Year,
+}
+
+/// The `RelativeTime` enum represents the different types of relative time. It
+/// can be a specific time unit with displacement (like "2 hours") or a day shift
+/// (like "today").
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum RelativeTime {
+    Now,
+    Today,
+    Tomorrow,
+    Yesterday,
+    Displacement { value: i64, unit: TimeUnit },
+}
+
+fn find_in_pairs<T: Clone>(pairs: &[(&str, T)], key: &str) -> Option<T> {
+    pairs.iter().find_map(|(k, v)| {
+        if k.eq_ignore_ascii_case(key) {
+            Some(v.clone())
+        } else {
+            None
+        }
+    })
+}
+
+pub(super) fn relative_times(input: &str) -> IResult<&str, Vec<RelativeTime>> {
+    all_consuming(separated_list0(
+        alt((
+            preceded(multispace0, terminated(tag(","), multispace0)),
+            preceded(multispace1, terminated(tag_no_case("and"), multispace1)),
+            multispace0,
+        )),
+        relative_time,
+    ))
+    .parse(input)
+}
+
+fn relative_time(input: &str) -> IResult<&str, RelativeTime> {
+    alt((day_shift, displacement)).parse(input)
+}
+
+fn displacement(input: &str) -> IResult<&str, RelativeTime> {
+    let (rest, (value, unit, ago)) = (
+        opt(terminated(alt((ordinal, integer)), multispace0)),
+        unit,
+        opt(preceded(multispace1, ago)),
+    )
+        .parse(input)?;
+
+    let mut value = value.unwrap_or(1);
+    if ago.unwrap_or(false) {
+        value = -value;
+    }
+
+    Ok((rest, RelativeTime::Displacement { value, unit }))
+}
+
+fn ago(input: &str) -> IResult<&str, bool> {
+    map_res(take_while1(|c: char| c.is_alphabetic()), |s: &str| {
+        if s.eq_ignore_ascii_case("ago") {
+            Ok(true)
+        } else {
+            Err("not ago")
+        }
+    })
+    .parse(input)
+}
+
+fn unit(input: &str) -> IResult<&str, TimeUnit> {
+    map_res(take_while1(|c: char| c.is_alphabetic()), |s: &str| {
+        find_in_pairs(TIME_UNITS, s).ok_or("unknown time unit")
+    })
+    .parse(input)
+}
+
+fn day_shift(input: &str) -> IResult<&str, RelativeTime> {
+    map_res(take_while1(|c: char| c.is_alphabetic()), |s: &str| {
+        find_in_pairs(DAY_SHIFTS, s).ok_or("unknown day shift")
+    })
+    .parse(input)
+}
+
+fn ordinal(input: &str) -> IResult<&str, i64> {
+    map_res(take_while1(|c: char| c.is_alphabetic()), |s: &str| {
+        find_in_pairs(ORDINALS, s).ok_or("unknown ordinal")
+    })
+    .parse(input)
+}
+
+fn integer(input: &str) -> IResult<&str, i64> {
+    let (rest, sign) = opt(sign).parse(input)?;
+    let (rest, num) = map_res(digit1, str::parse::<i64>).parse(rest)?;
+    if sign == Some('-') {
+        Ok((rest, -num))
+    } else {
+        Ok((rest, num))
+    }
+}
+
+/// Parses a sign (either + or -) from the input string. The input string must
+/// start with a sign character followed by arbitrary number of interleaving
+/// sign characters and whitespace characters. All but the last sign character
+/// is ignored, and the last sign character is returned as the result. This
+/// quirky behavior is to stay consistent with GNU date.
+fn sign(input: &str) -> IResult<&str, char> {
+    fold_many1(
+        terminated(one_of("+-"), multispace0),
+        || '+',
+        |acc, c| if "+-".contains(c) { c } else { acc },
+    )
+    .parse(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_relative_times() {
+        assert!(relative_times(" ").is_err());
+        assert!(relative_times("invalid").is_err());
+
+        assert_eq!(relative_times(""), Ok(("", vec![])));
+
+        assert_eq!(
+            relative_times("second"),
+            Ok((
+                "",
+                vec![RelativeTime::Displacement {
+                    value: 1,
+                    unit: TimeUnit::Second
+                }]
+            ))
+        );
+        assert_eq!(
+            relative_times("2 minutes"),
+            Ok((
+                "",
+                vec![RelativeTime::Displacement {
+                    value: 2,
+                    unit: TimeUnit::Minute
+                }]
+            ))
+        );
+        assert_eq!(
+            relative_times("3 hours ago"),
+            Ok((
+                "",
+                vec![RelativeTime::Displacement {
+                    value: -3,
+                    unit: TimeUnit::Hour
+                }]
+            ))
+        );
+
+        // Space separator
+        assert_eq!(
+            relative_times("today tomorrow"),
+            Ok(("", vec![RelativeTime::Today, RelativeTime::Tomorrow]))
+        );
+
+        // Comma separator
+        assert_eq!(
+            relative_times("today, tomorrow"),
+            Ok(("", vec![RelativeTime::Today, RelativeTime::Tomorrow]))
+        );
+        assert_eq!(
+            relative_times("today ,tomorrow"),
+            Ok(("", vec![RelativeTime::Today, RelativeTime::Tomorrow]))
+        );
+        assert_eq!(
+            relative_times("today , tomorrow"),
+            Ok(("", vec![RelativeTime::Today, RelativeTime::Tomorrow]))
+        );
+
+        // "and" separator
+        assert_eq!(
+            relative_times("today and tomorrow"),
+            Ok(("", vec![RelativeTime::Today, RelativeTime::Tomorrow]))
+        );
+
+        // Mixed separator
+        assert_eq!(
+            relative_times("yesterday, today and tomorrow"),
+            Ok((
+                "",
+                vec![
+                    RelativeTime::Yesterday,
+                    RelativeTime::Today,
+                    RelativeTime::Tomorrow
+                ]
+            ))
+        );
+
+        // Boundary
+        assert_eq!(
+            relative_times("1week2months-3years"),
+            Ok((
+                "",
+                vec![
+                    RelativeTime::Displacement {
+                        value: 1,
+                        unit: TimeUnit::Week
+                    },
+                    RelativeTime::Displacement {
+                        value: 2,
+                        unit: TimeUnit::Month
+                    },
+                    RelativeTime::Displacement {
+                        value: -3,
+                        unit: TimeUnit::Year
+                    }
+                ]
+            ))
+        );
+        assert!(relative_times("1week2months-3years123").is_err());
+        assert!(relative_times("1week2months-3yearsabc").is_err());
+    }
+
+    #[test]
+    fn test_relative_time() {
+        assert!(relative_time("").is_err());
+        assert!(relative_time("invalid").is_err());
+
+        assert_eq!(
+            relative_time("second"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: 1,
+                    unit: TimeUnit::Second
+                }
+            ))
+        );
+        assert_eq!(
+            relative_time("2 minutes"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: 2,
+                    unit: TimeUnit::Minute
+                }
+            ))
+        );
+        assert_eq!(
+            relative_time("3 hours ago"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: -3,
+                    unit: TimeUnit::Hour
+                }
+            ))
+        );
+        assert_eq!(
+            relative_time("last day"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: -1,
+                    unit: TimeUnit::Day
+                }
+            ))
+        );
+        assert_eq!(
+            relative_time("twelfth week"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: 12,
+                    unit: TimeUnit::Week
+                }
+            ))
+        );
+        assert_eq!(relative_time("now"), Ok(("", RelativeTime::Now)));
+        assert_eq!(relative_time("today"), Ok(("", RelativeTime::Today)));
+    }
+
+    #[test]
+    fn test_displacement() {
+        assert!(displacement("").is_err());
+        assert!(displacement("invalid").is_err());
+
+        assert_eq!(
+            displacement("second"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: 1,
+                    unit: TimeUnit::Second
+                }
+            ))
+        );
+        assert_eq!(
+            displacement("2 minutes"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: 2,
+                    unit: TimeUnit::Minute
+                }
+            ))
+        );
+        assert_eq!(
+            displacement("3 hours ago"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: -3,
+                    unit: TimeUnit::Hour
+                }
+            ))
+        );
+        assert_eq!(
+            displacement("last day"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: -1,
+                    unit: TimeUnit::Day
+                }
+            ))
+        );
+        assert_eq!(
+            displacement("twelfth week"),
+            Ok((
+                "",
+                RelativeTime::Displacement {
+                    value: 12,
+                    unit: TimeUnit::Week
+                }
+            ))
+        );
+
+        // Boundary
+        assert_eq!(
+            displacement("3 hours123"),
+            Ok((
+                "123",
+                RelativeTime::Displacement {
+                    value: 3,
+                    unit: TimeUnit::Hour
+                }
+            ))
+        );
+        assert!(displacement("3 hoursabc").is_err());
+        assert_eq!(
+            displacement("3 hours ago123"),
+            Ok((
+                "123",
+                RelativeTime::Displacement {
+                    value: -3,
+                    unit: TimeUnit::Hour
+                }
+            ))
+        );
+        assert_eq!(
+            displacement("3 hours ago abc"),
+            Ok((
+                " abc",
+                RelativeTime::Displacement {
+                    value: -3,
+                    unit: TimeUnit::Hour
+                }
+            ))
+        );
+        assert_eq!(
+            displacement("3 hours agoabc"),
+            Ok((
+                " agoabc",
+                RelativeTime::Displacement {
+                    value: 3,
+                    unit: TimeUnit::Hour
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_ago() {
+        assert!(ago("").is_err());
+        assert!(ago("invalid").is_err());
+
+        assert_eq!(ago("ago"), Ok(("", true)));
+
+        // Boundary
+        assert_eq!(ago("ago123"), Ok(("123", true)));
+        assert_eq!(ago("ago abc"), Ok((" abc", true)));
+        assert!(ago("agoabc").is_err());
+    }
+
+    #[test]
+    fn test_unit() {
+        assert!(day_shift("").is_err());
+        assert!(unit("invalid").is_err());
+        assert!(unit(" second").is_err());
+
+        assert_eq!(unit("seconds"), Ok(("", TimeUnit::Second)));
+        assert_eq!(unit("second"), Ok(("", TimeUnit::Second)));
+        assert_eq!(unit("secs"), Ok(("", TimeUnit::Second)));
+        assert_eq!(unit("sec"), Ok(("", TimeUnit::Second)));
+        assert_eq!(unit("s"), Ok(("", TimeUnit::Second)));
+        assert_eq!(unit("minutes"), Ok(("", TimeUnit::Minute)));
+        assert_eq!(unit("minute"), Ok(("", TimeUnit::Minute)));
+        assert_eq!(unit("mins"), Ok(("", TimeUnit::Minute)));
+        assert_eq!(unit("min"), Ok(("", TimeUnit::Minute)));
+        assert_eq!(unit("m"), Ok(("", TimeUnit::Minute)));
+        assert_eq!(unit("hours"), Ok(("", TimeUnit::Hour)));
+        assert_eq!(unit("hour"), Ok(("", TimeUnit::Hour)));
+        assert_eq!(unit("days"), Ok(("", TimeUnit::Day)));
+        assert_eq!(unit("day"), Ok(("", TimeUnit::Day)));
+        assert_eq!(unit("weeks"), Ok(("", TimeUnit::Week)));
+        assert_eq!(unit("week"), Ok(("", TimeUnit::Week)));
+        assert_eq!(unit("fortnights"), Ok(("", TimeUnit::Fortnight)));
+        assert_eq!(unit("fortnight"), Ok(("", TimeUnit::Fortnight)));
+        assert_eq!(unit("months"), Ok(("", TimeUnit::Month)));
+        assert_eq!(unit("month"), Ok(("", TimeUnit::Month)));
+        assert_eq!(unit("years"), Ok(("", TimeUnit::Year)));
+        assert_eq!(unit("year"), Ok(("", TimeUnit::Year)));
+
+        // Boundary
+        assert_eq!(unit("second123"), Ok(("123", TimeUnit::Second)));
+        assert_eq!(unit("second abc"), Ok((" abc", TimeUnit::Second)));
+        assert!(unit("secondabc").is_err());
+
+        // Case insensitive
+        assert_eq!(unit("SECOND"), Ok(("", TimeUnit::Second)));
+        assert_eq!(unit("Second"), Ok(("", TimeUnit::Second)));
+    }
+
+    #[test]
+    fn test_day_shift() {
+        assert!(day_shift("").is_err());
+        assert!(day_shift("invalid").is_err());
+        assert!(day_shift(" now").is_err());
+
+        assert_eq!(day_shift("now"), Ok(("", RelativeTime::Now)));
+        assert_eq!(day_shift("today"), Ok(("", RelativeTime::Today)));
+        assert_eq!(day_shift("tomorrow"), Ok(("", RelativeTime::Tomorrow)));
+        assert_eq!(day_shift("yesterday"), Ok(("", RelativeTime::Yesterday)));
+
+        // Boundary
+        assert_eq!(day_shift("now123"), Ok(("123", RelativeTime::Now)));
+        assert_eq!(day_shift("now abc"), Ok((" abc", RelativeTime::Now)));
+        assert!(day_shift("nowabc").is_err());
+
+        // Case insensitive
+        assert_eq!(day_shift("NOW"), Ok(("", RelativeTime::Now)));
+        assert_eq!(day_shift("Now"), Ok(("", RelativeTime::Now)));
+    }
+
+    #[test]
+    fn test_ordinal() {
+        assert!(ordinal("").is_err());
+        assert!(ordinal("invalid").is_err());
+        assert!(ordinal(" last").is_err());
+
+        assert_eq!(ordinal("last"), Ok(("", -1)));
+        assert_eq!(ordinal("this"), Ok(("", 0)));
+        assert_eq!(ordinal("next"), Ok(("", 1)));
+        assert_eq!(ordinal("first"), Ok(("", 1)));
+        assert_eq!(ordinal("third"), Ok(("", 3)));
+        assert_eq!(ordinal("fourth"), Ok(("", 4)));
+        assert_eq!(ordinal("fifth"), Ok(("", 5)));
+        assert_eq!(ordinal("sixth"), Ok(("", 6)));
+        assert_eq!(ordinal("seventh"), Ok(("", 7)));
+        assert_eq!(ordinal("eighth"), Ok(("", 8)));
+        assert_eq!(ordinal("ninth"), Ok(("", 9)));
+        assert_eq!(ordinal("tenth"), Ok(("", 10)));
+        assert_eq!(ordinal("eleventh"), Ok(("", 11)));
+        assert_eq!(ordinal("twelfth"), Ok(("", 12)));
+
+        // Boundary
+        assert_eq!(ordinal("last123"), Ok(("123", -1)));
+        assert_eq!(ordinal("last abc"), Ok((" abc", -1)));
+        assert!(ordinal("lastabc").is_err());
+
+        // Case insensitive
+        assert_eq!(ordinal("THIS"), Ok(("", 0)));
+        assert_eq!(ordinal("This"), Ok(("", 0)));
+    }
+
+    #[test]
+    fn test_integer() {
+        assert!(integer("").is_err());
+        assert!(integer("invalid").is_err());
+        assert!(integer(" 123").is_err());
+
+        assert_eq!(integer("123"), Ok(("", 123)));
+        assert_eq!(integer("+123"), Ok(("", 123)));
+        assert_eq!(integer("- 123"), Ok(("", -123)));
+
+        // Boundary
+        assert_eq!(integer("- 123abc"), Ok(("abc", -123)));
+        assert_eq!(integer("- +- 123abc"), Ok(("abc", -123)));
+    }
+
+    #[test]
+    fn test_sign() {
+        assert!(sign("").is_err());
+        assert!(sign("invalid").is_err());
+        assert!(sign(" +").is_err());
+
+        assert_eq!(sign("+"), Ok(("", '+')));
+        assert_eq!(sign("-"), Ok(("", '-')));
+        assert_eq!(sign("- + - "), Ok(("", '-')));
+
+        // Boundary
+        assert_eq!(sign("- + - abc"), Ok(("abc", '-')));
+    }
+}

--- a/src/parse/timestamp.rs
+++ b/src/parse/timestamp.rs
@@ -1,0 +1,73 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Module to parser timestamp strings.
+//!
+//! Grammar definition:
+//!
+//! ```ebnf
+//! timestamp = "@" seconds ;
+//!
+//! seconds = [ sign ] , { digit } , [ ("." | ",") , { digit } ] ;
+//! ```
+
+use nom::{
+    bytes::complete::tag,
+    character::complete::{digit1, one_of},
+    combinator::{all_consuming, map_res, opt, recognize},
+    sequence::preceded,
+    IResult, Parser,
+};
+
+use super::primitive::sign;
+
+pub(super) fn timestamp(input: &str) -> IResult<&str, f64> {
+    all_consuming(preceded(tag("@"), seconds)).parse(input)
+}
+
+fn seconds(input: &str) -> IResult<&str, f64> {
+    let (rest, sign) = opt(sign).parse(input)?;
+    let (rest, num) = map_res(
+        recognize((digit1, opt((one_of(".,"), digit1)))),
+        |s: &str| {
+            s.replace(",", ".")
+                .parse::<f64>()
+                .map_err(|_| "invalid seconds")
+        },
+    )
+    .parse(rest)?;
+
+    let num = if sign == Some('-') { -num } else { num };
+    Ok((rest, num))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp() {
+        assert!(timestamp("invalid").is_err());
+
+        assert_eq!(timestamp("@-1234.567"), Ok(("", -1234.567)));
+        assert_eq!(timestamp("@1234,567"), Ok(("", 1234.567)));
+        assert_eq!(timestamp("@- 1234.567"), Ok(("", -1234.567)));
+        assert_eq!(timestamp("@-+- 1234,567"), Ok(("", -1234.567)));
+        assert_eq!(timestamp("@1234"), Ok(("", 1234.0)));
+        assert_eq!(timestamp("@-1234"), Ok(("", -1234.0)));
+    }
+
+    #[test]
+    fn test_seconds() {
+        assert!(seconds("").is_err());
+        assert!(seconds("invalid").is_err());
+
+        assert_eq!(seconds("-1234.567"), Ok(("", -1234.567)));
+        assert_eq!(seconds("1234,567"), Ok(("", 1234.567)));
+        assert_eq!(seconds("- 1234.567"), Ok(("", -1234.567)));
+        assert_eq!(seconds("-+- 1234,567"), Ok(("", -1234.567)));
+        assert_eq!(seconds("1234"), Ok(("", 1234.0)));
+        assert_eq!(seconds("-1234"), Ok(("", -1234.0)));
+        assert_eq!(seconds("1234.567abc"), Ok(("abc", 1234.567)));
+    }
+}

--- a/src/parse/weekday.rs
+++ b/src/parse/weekday.rs
@@ -14,7 +14,7 @@
 //!     | "wednesday" | "wednes" | "wed"
 //!     | "thursday" | "thurs" | "thur" | "thu"
 //!     | "friday" | "fri"
-//!     | "saturday" | "sat"
+//!     | "saturday" | "sat" ;
 //! ```
 
 use chrono::Weekday;

--- a/src/parse/weekday.rs
+++ b/src/parse/weekday.rs
@@ -1,0 +1,242 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Module to parser weekday strings.
+//!
+//! Grammar definition:
+//!
+//! ```ebnf
+//! weekday = (integer | ordinal) , day | day , [ "," ] ;
+//!
+//! day = "sunday" | "sun"
+//!     | "monday" | "mon"
+//!     | "tuesday" | "tues" | "tue"
+//!     | "wednesday" | "wednes" | "wed"
+//!     | "thursday" | "thurs" | "thur" | "thu"
+//!     | "friday" | "fri"
+//!     | "saturday" | "sat"
+//! ```
+
+use chrono::Weekday;
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_while1},
+    character::complete::multispace0,
+    combinator::{all_consuming, map_res, opt},
+    sequence::{preceded, terminated},
+    IResult, Parser,
+};
+
+use super::{
+    find_in_pairs,
+    primitive::{integer, ordinal},
+};
+
+const DAYS: &[(&str, Weekday)] = &[
+    ("sunday", Weekday::Sun),
+    ("sun", Weekday::Sun),
+    ("monday", Weekday::Mon),
+    ("mon", Weekday::Mon),
+    ("tuesday", Weekday::Tue),
+    ("tues", Weekday::Tue),
+    ("tue", Weekday::Tue),
+    ("wednesday", Weekday::Wed),
+    ("wednes", Weekday::Wed),
+    ("wed", Weekday::Wed),
+    ("thursday", Weekday::Thu),
+    ("thurs", Weekday::Thu),
+    ("thur", Weekday::Thu),
+    ("thu", Weekday::Thu),
+    ("friday", Weekday::Fri),
+    ("fri", Weekday::Fri),
+    ("saturday", Weekday::Sat),
+    ("sat", Weekday::Sat),
+];
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct WeekdayItem {
+    pub weekday: Weekday,
+    pub ordinal: Option<i64>,
+}
+
+pub(super) fn weekday(input: &str) -> IResult<&str, WeekdayItem> {
+    all_consuming(alt((ordinal_day, day_comma))).parse(input)
+}
+
+fn ordinal_day(input: &str) -> IResult<&str, WeekdayItem> {
+    map_res(
+        (alt((ordinal, integer)), preceded(multispace0, day)),
+        |(ordinal, weekday): (i64, Weekday)| {
+            Ok::<WeekdayItem, &str>(WeekdayItem {
+                weekday,
+                ordinal: Some(ordinal),
+            })
+        },
+    )
+    .parse(input)
+}
+
+fn day_comma(input: &str) -> IResult<&str, WeekdayItem> {
+    map_res(
+        terminated(day, opt(preceded(multispace0, tag(",")))),
+        |s: Weekday| {
+            Ok::<WeekdayItem, &str>(WeekdayItem {
+                weekday: s,
+                ordinal: None,
+            })
+        },
+    )
+    .parse(input)
+}
+
+fn day(input: &str) -> IResult<&str, Weekday> {
+    map_res(take_while1(|c: char| c.is_alphabetic()), |s: &str| {
+        find_in_pairs(DAYS, s).ok_or("unknown weekday")
+    })
+    .parse(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_weekday() {
+        assert!(weekday("").is_err());
+        assert!(weekday("invalid").is_err());
+        assert!(weekday(" sun").is_err());
+
+        assert_eq!(
+            weekday("last sunday"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: Some(-1)
+                }
+            ))
+        );
+        assert_eq!(
+            weekday("sunday ,"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: None
+                }
+            ))
+        );
+        assert!(weekday("next sunday,").is_err());
+    }
+
+    #[test]
+    fn test_ordinal_day() {
+        assert!(ordinal_day("").is_err());
+        assert!(ordinal_day("invalid").is_err());
+        assert!(ordinal_day(" sun").is_err());
+
+        assert_eq!(
+            ordinal_day("last sunday"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: Some(-1)
+                }
+            ))
+        );
+        assert_eq!(
+            ordinal_day("2 sun"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: Some(2)
+                }
+            ))
+        );
+        assert_eq!(
+            ordinal_day("2sun"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: Some(2)
+                }
+            ))
+        );
+        assert!(ordinal_day("nextsun").is_err());
+    }
+
+    #[test]
+    fn test_day_comma() {
+        assert!(day_comma("").is_err());
+        assert!(day_comma("invalid").is_err());
+        assert!(day_comma(" sun").is_err());
+
+        assert_eq!(
+            day_comma("sunday"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: None
+                }
+            ))
+        );
+        assert_eq!(
+            day_comma("sun,"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: None
+                }
+            ))
+        );
+        assert_eq!(
+            day_comma("sun ,"),
+            Ok((
+                "",
+                WeekdayItem {
+                    weekday: Weekday::Sun,
+                    ordinal: None
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_day() {
+        assert!(day("").is_err());
+        assert!(day("invalid").is_err());
+        assert!(day(" sun").is_err());
+
+        assert_eq!(day("sunday"), Ok(("", Weekday::Sun)));
+        assert_eq!(day("sun"), Ok(("", Weekday::Sun)));
+        assert_eq!(day("monday"), Ok(("", Weekday::Mon)));
+        assert_eq!(day("mon"), Ok(("", Weekday::Mon)));
+        assert_eq!(day("tuesday"), Ok(("", Weekday::Tue)));
+        assert_eq!(day("tues"), Ok(("", Weekday::Tue)));
+        assert_eq!(day("tue"), Ok(("", Weekday::Tue)));
+        assert_eq!(day("wednesday"), Ok(("", Weekday::Wed)));
+        assert_eq!(day("wednes"), Ok(("", Weekday::Wed)));
+        assert_eq!(day("wed"), Ok(("", Weekday::Wed)));
+        assert_eq!(day("thursday"), Ok(("", Weekday::Thu)));
+        assert_eq!(day("thur"), Ok(("", Weekday::Thu)));
+        assert_eq!(day("thu"), Ok(("", Weekday::Thu)));
+        assert_eq!(day("friday"), Ok(("", Weekday::Fri)));
+        assert_eq!(day("fri"), Ok(("", Weekday::Fri)));
+        assert_eq!(day("saturday"), Ok(("", Weekday::Sat)));
+        assert_eq!(day("sat"), Ok(("", Weekday::Sat)));
+
+        // Boundary
+        assert_eq!(day("sun123"), Ok(("123", Weekday::Sun)));
+        assert_eq!(day("sun abc"), Ok((" abc", Weekday::Sun)));
+        assert!(day("sunabc").is_err());
+
+        // Case insensitive
+        assert_eq!(day("MONDAY"), Ok(("", Weekday::Mon)));
+        assert_eq!(day("Monday"), Ok(("", Weekday::Mon)));
+    }
+}


### PR DESCRIPTION
This PR is built on top of #132.

New feature: the parser now supports timestamp strings containing an internal decimal point (either '.' or ',').