### PR TITLE
use a custom float parser

### DIFF
--- a/src/items/relative.rs
+++ b/src/items/relative.rs
@@ -32,12 +32,12 @@
 //! > ‘this thursday’.
 
 use winnow::{
-    ascii::{alpha1, float},
+    ascii::alpha1,
     combinator::{alt, opt},
     ModalResult, Parser,
 };
 
-use super::{ordinal::ordinal, s};
+use super::{float, ordinal::ordinal, s};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Relative {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,13 @@ mod tests {
 
         #[test]
         fn invalid_formats() {
-            let invalid_dts = vec!["NotADate", "202104", "202104-12T22:37:47"];
+            let invalid_dts = vec![
+                "NotADate",
+                "202104",
+                "202104-12T22:37:47",
+                "a774e26sec", // 774e26 is not a valid seconds value (we don't accept E-notation)
+                "12.",        // Invalid floating point number
+            ];
             for dt in invalid_dts {
                 assert_eq!(parse_datetime(dt), Err(ParseDateTimeError::InvalidInput));
             }


### PR DESCRIPTION
The `float` parser provided by winnow accepts E-notation numbers (e.g., `1.23e4`), whereas GNU date rejects such numbers. We craft a custom float parser to stay compatible with GNU date.