### PR TITLE
fix: check whether the parsed time contains timezone

### DIFF
--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -258,10 +258,18 @@ pub fn parse(input: &mut &str) -> ModalResult<Vec<Item>> {
                         if time_seen {
                             return Err(expect_error(input, "time cannot appear more than once"));
                         }
-                        time_seen = true;
+
                         if t.offset.is_some() {
+                            if tz_seen {
+                                return Err(expect_error(
+                                    input,
+                                    "timezone cannot appear more than once",
+                                ));
+                            }
                             tz_seen = true;
                         }
+
+                        time_seen = true;
                     }
                     Item::Year(_) => {
                         if year_seen {
@@ -585,6 +593,13 @@ mod tests {
             .contains("year cannot appear more than once"));
 
         let result = parse(&mut "2025-05-19 +00:00 +01:00");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("timezone cannot appear more than once"));
+
+        let result = parse(&mut "m1y");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()


### PR DESCRIPTION
Closes #147.

Why `m1y` was accepted: `m1y` was parsed as an offset `m` and a time `1y`; the time `1y` contains two elements: the hour `1` and the offset `y`. So the problem here is the duplication of offsets.

cc @drinkcat 