### PR TITLE
tests: set timezone to `UTC0` in integration tests

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,10 +1,14 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+use std::env;
+
 use chrono::{DateTime, FixedOffset};
 use parse_datetime::{parse_datetime, parse_datetime_at_date};
 
 pub fn check_absolute(input: &str, expected: &str) {
+    env::set_var("TZ", "UTC0");
+
     let parsed = match parse_datetime(input) {
         Ok(v) => v,
         Err(e) => panic!("Failed to parse date from value '{input}': {e}"),
@@ -18,6 +22,8 @@ pub fn check_absolute(input: &str, expected: &str) {
 }
 
 pub fn check_relative(now: DateTime<FixedOffset>, input: &str, expected: &str) {
+    env::set_var("TZ", "UTC0");
+
     let parsed = match parse_datetime_at_date(now.into(), input) {
         Ok(v) => v,
         Err(e) => panic!("Failed to parse date from value '{input}': {e}"),


### PR DESCRIPTION
Fixes the issue I mentioned in https://github.com/uutils/parse_datetime/pull/161#issuecomment-2999980201