### PR TITLE
clippy: fix warning from `uninlined_format_args`

### DIFF
--- a/src/items/time.rs
+++ b/src/items/time.rs
@@ -840,7 +840,7 @@ mod tests {
         let make_timezone = |input: &mut &str| {
             timezone(input)
                 .map_err(|e| eprintln!("TEST FAILED AT:\n{e}"))
-                .map(|offset| format!("{}", offset))
+                .map(|offset| format!("{offset}"))
                 .expect("expect tests to succeed")
         };
 


### PR DESCRIPTION
This PR fixes a warning from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint.