### PR TITLE
fix base datetime handling in the builder

### DIFF
--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -446,6 +446,12 @@ mod tests {
         assert_eq!(result.minute(), now.minute());
         assert_eq!(result.second(), now.second());
 
+        let result = at_date(parse(&mut "2 days 3 days ago").unwrap(), now).unwrap();
+        assert_eq!(result, now - chrono::Duration::days(1));
+        assert_eq!(result.hour(), now.hour());
+        assert_eq!(result.minute(), now.minute());
+        assert_eq!(result.second(), now.second());
+
         let result = at_date(parse(&mut "2025-01-01 2 days ago").unwrap(), now).unwrap();
         assert_eq!(result.hour(), 0);
         assert_eq!(result.minute(), 0);


### PR DESCRIPTION
The old logic is problematic: it resets the value of the `dt` variable at each iteration of the relative item processing. We fix it by moving the base datetime truncating logic to the start of the `build()` method.

After this fix gets merged, we can close #131.