### PR TITLE
feat: implement pure number parsing

### DIFF
--- a/src/items/pure.rs
+++ b/src/items/pure.rs
@@ -1,0 +1,33 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Parse a pure number string.
+//!
+//! The GNU docs say:
+//!
+//! > The precise interpretation of a pure decimal number depends on the
+//! > context in the date string.
+//! >
+//! >    If the decimal number is of the form YYYYMMDD and no other calendar
+//! > date item (*note Calendar date items::) appears before it in the date
+//! > string, then YYYY is read as the year, MM as the month number and DD as
+//! > the day of the month, for the specified calendar date.
+//! >
+//! >    If the decimal number is of the form HHMM and no other time of day
+//! > item appears before it in the date string, then HH is read as the hour
+//! > of the day and MM as the minute of the hour, for the specified time of
+//! > day.  MM can also be omitted.
+//! >
+//! >    If both a calendar date and a time of day appear to the left of a
+//! > number in the date string, but no relative item, then the number
+//! > overrides the year.
+
+use winnow::{stream::AsChar, token::take_while, ModalResult, Parser};
+
+use super::primitive::s;
+
+pub(super) fn parse(input: &mut &str) -> ModalResult<String> {
+    s(take_while(1.., AsChar::is_dec_digit))
+        .map(|s: &str| s.to_owned())
+        .parse_next(input)
+}

--- a/src/items/time.rs
+++ b/src/items/time.rs
@@ -214,7 +214,7 @@ fn colon(input: &mut &str) -> ModalResult<()> {
 }
 
 /// Parse a number of hours in `0..24`(preceded by whitespace)
-fn hour24(input: &mut &str) -> ModalResult<u32> {
+pub(super) fn hour24(input: &mut &str) -> ModalResult<u32> {
     s(dec_uint).verify(|x| *x < 24).parse_next(input)
 }
 
@@ -224,7 +224,7 @@ fn hour12(input: &mut &str) -> ModalResult<u32> {
 }
 
 /// Parse a number of minutes (preceded by whitespace)
-fn minute(input: &mut &str) -> ModalResult<u32> {
+pub(super) fn minute(input: &mut &str) -> ModalResult<u32> {
     s(dec_uint).verify(|x| *x < 60).parse_next(input)
 }
 

--- a/src/items/year.rs
+++ b/src/items/year.rs
@@ -10,13 +10,9 @@
 //! strings. For example, `"00"` is interpreted as `2000`, whereas `"0"`,
 //! `"000"`, or `"0000"` are interpreted as `0`.
 
-use winnow::{error::ErrMode, stream::AsChar, token::take_while, ModalResult, Parser};
+use winnow::{stream::AsChar, token::take_while, ModalResult, Parser};
 
-use super::primitive::{ctx_err, s};
-
-pub(super) fn parse(input: &mut &str) -> ModalResult<u32> {
-    year_from_str(year_str(input)?).map_err(|e| ErrMode::Cut(ctx_err(e)))
-}
+use super::primitive::s;
 
 // TODO: Leverage `TryFrom` trait.
 pub(super) fn year_from_str(year_str: &str) -> Result<u32, &'static str> {
@@ -56,23 +52,23 @@ pub(super) fn year_str<'a>(input: &mut &'a str) -> ModalResult<&'a str> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse;
+    use super::year_from_str;
 
     #[test]
     fn test_year() {
         // 2-characters are converted to 19XX/20XX
-        assert_eq!(parse(&mut "10").unwrap(), 2010u32);
-        assert_eq!(parse(&mut "68").unwrap(), 2068u32);
-        assert_eq!(parse(&mut "69").unwrap(), 1969u32);
-        assert_eq!(parse(&mut "99").unwrap(), 1999u32);
+        assert_eq!(year_from_str("10").unwrap(), 2010u32);
+        assert_eq!(year_from_str("68").unwrap(), 2068u32);
+        assert_eq!(year_from_str("69").unwrap(), 1969u32);
+        assert_eq!(year_from_str("99").unwrap(), 1999u32);
 
         // 3,4-characters are converted verbatim
-        assert_eq!(parse(&mut "468").unwrap(), 468u32);
-        assert_eq!(parse(&mut "469").unwrap(), 469u32);
-        assert_eq!(parse(&mut "1568").unwrap(), 1568u32);
-        assert_eq!(parse(&mut "1569").unwrap(), 1569u32);
+        assert_eq!(year_from_str("468").unwrap(), 468u32);
+        assert_eq!(year_from_str("469").unwrap(), 469u32);
+        assert_eq!(year_from_str("1568").unwrap(), 1568u32);
+        assert_eq!(year_from_str("1569").unwrap(), 1569u32);
 
         // years greater than 9999 are not accepted
-        assert!(parse(&mut "10000").is_err());
+        assert!(year_from_str("10000").is_err());
     }
 }


### PR DESCRIPTION
Implement GNU-compatible pure number interpretation that treats pure number as year or time based on the current parsing context.

Closes #197.