### PR TITLE
refactor: replace floating-point seconds with precise integer representation

### DIFF
--- a/src/items/combined.rs
+++ b/src/items/combined.rs
@@ -55,7 +55,8 @@ mod tests {
             time: Time {
                 hour: 10,
                 minute: 10,
-                second: 55.0,
+                second: 55,
+                nanosecond: 0,
                 offset: None,
             },
         });

--- a/src/items/epoch.rs
+++ b/src/items/epoch.rs
@@ -15,35 +15,147 @@
 //! > ‘@1483228800’ represents 2017-01-01 00:00:00 UTC, and there is no way to
 //! > represent the intervening leap second 2016-12-31 23:59:60 UTC.
 
-use winnow::{combinator::preceded, ModalResult, Parser};
+use winnow::{
+    ascii::digit1,
+    combinator::{opt, preceded},
+    token::one_of,
+    ModalResult, Parser,
+};
 
-use super::primitive::{float, s};
+use super::primitive::{dec_uint, s};
 
-/// Parse a timestamp in the form of `@1234567890`.
-pub fn parse(input: &mut &str) -> ModalResult<f64> {
-    s(preceded("@", float)).parse_next(input)
+/// Represents a timestamp with nanosecond accuracy.
+///
+/// # Invariants
+///
+/// - `nanosecond` is always in the range of `0..1_000_000_000`.
+/// - Negative timestamps are represented by a negative `second` value and a
+///   positive `nanosecond` value.
+#[derive(Debug, PartialEq)]
+pub(crate) struct Timestamp {
+    pub(crate) second: i64,
+    pub(crate) nanosecond: u32,
+}
+
+/// Parse a timestamp in the form of `1234567890` or `-1234567890.12345` or
+/// `1234567890,12345`.
+pub(crate) fn parse(input: &mut &str) -> ModalResult<Timestamp> {
+    (s("@"), opt(s(one_of(['-', '+']))), sec_and_nsec)
+        .verify_map(|(_, sign, (sec, nsec))| {
+            let sec = i64::try_from(sec).ok()?;
+            let (second, nanosecond) = match (sign, nsec) {
+                (Some('-'), 0) => (-sec, 0),
+                // Truncate towards minus infinity.
+                (Some('-'), _) => ((-sec).checked_sub(1)?, 1_000_000_000 - nsec),
+                _ => (sec, nsec),
+            };
+            Some(Timestamp { second, nanosecond })
+        })
+        .parse_next(input)
+}
+
+/// Parse a second value in the form of `1234567890` or `1234567890.12345` or
+/// `1234567890,12345`.
+///
+/// The first part represents whole seconds. The optional second part represents
+/// fractional seconds, parsed as a nanosecond value from up to 9 digits
+/// (padded with zeros on the right if fewer digits are present). If the second
+/// part is omitted, it defaults to 0 nanoseconds.
+pub(super) fn sec_and_nsec(input: &mut &str) -> ModalResult<(u64, u32)> {
+    (s(dec_uint), opt(preceded(one_of(['.', ',']), digit1)))
+        .verify_map(|(sec, opt_nsec_str)| match opt_nsec_str {
+            Some(nsec_str) if nsec_str.len() >= 9 => Some((sec, nsec_str[..9].parse().ok()?)),
+            Some(nsec_str) => {
+                let multiplier = 10_u32.pow(9 - nsec_str.len() as u32);
+                Some((sec, nsec_str.parse::<u32>().ok()?.checked_mul(multiplier)?))
+            }
+            None => Some((sec, 0)),
+        })
+        .parse_next(input)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse;
+    use super::*;
 
-    fn float_eq(a: f64, b: f64) -> bool {
-        (a - b).abs() < f64::EPSILON
+    #[test]
+    fn sec_and_nsec_test() {
+        let mut input = "1234567890";
+        assert_eq!(sec_and_nsec(&mut input).unwrap(), (1234567890, 0));
+
+        let mut input = "1234567890.12345";
+        assert_eq!(sec_and_nsec(&mut input).unwrap(), (1234567890, 123450000));
+
+        let mut input = "1234567890,12345";
+        assert_eq!(sec_and_nsec(&mut input).unwrap(), (1234567890, 123450000));
+
+        let mut input = "1234567890.1234567890123";
+        assert_eq!(sec_and_nsec(&mut input).unwrap(), (1234567890, 123456789));
     }
 
     #[test]
-    fn float() {
+    fn timestamp() {
         let mut input = "@1234567890";
-        assert!(float_eq(parse(&mut input).unwrap(), 1234567890.0));
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: 1234567890,
+                nanosecond: 0,
+            }
+        );
+
+        let mut input = "@ 1234567890";
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: 1234567890,
+                nanosecond: 0,
+            }
+        );
+
+        let mut input = "@ -1234567890";
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: -1234567890,
+                nanosecond: 0,
+            }
+        );
+
+        let mut input = "@ - 1234567890";
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: -1234567890,
+                nanosecond: 0,
+            }
+        );
 
         let mut input = "@1234567890.12345";
-        assert!(float_eq(parse(&mut input).unwrap(), 1234567890.12345));
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: 1234567890,
+                nanosecond: 123450000,
+            }
+        );
 
         let mut input = "@1234567890,12345";
-        assert!(float_eq(parse(&mut input).unwrap(), 1234567890.12345));
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: 1234567890,
+                nanosecond: 123450000,
+            }
+        );
 
         let mut input = "@-1234567890.12345";
-        assert_eq!(parse(&mut input).unwrap(), -1234567890.12345);
+        assert_eq!(
+            parse(&mut input).unwrap(),
+            Timestamp {
+                second: -1234567891,
+                nanosecond: 876550000,
+            }
+        );
     }
 }

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -58,7 +58,7 @@ use crate::ParseDateTimeError;
 
 #[derive(PartialEq, Debug)]
 pub(crate) enum Item {
-    Timestamp(f64),
+    Timestamp(epoch::Timestamp),
     DateTime(combined::DateTime),
     Date(date::Date),
     Time(time::Time),

--- a/src/items/primitive.rs
+++ b/src/items/primitive.rs
@@ -3,8 +3,10 @@
 
 //! Primitive combinators.
 
+use std::str::FromStr;
+
 use winnow::{
-    ascii::{digit1, multispace0},
+    ascii::{digit1, multispace0, Uint},
     combinator::{alt, delimited, not, opt, peek, preceded, repeat, separated},
     error::{ContextError, ParserError, StrContext, StrContextValue},
     stream::AsChar,
@@ -100,8 +102,9 @@ where
 ///
 /// See the rationale for `dec_int` for why we don't use
 /// `winnow::ascii::dec_uint`.
-pub(super) fn dec_uint<'a, E>(input: &mut &'a str) -> winnow::Result<u32, E>
+pub(super) fn dec_uint<'a, O, E>(input: &mut &'a str) -> winnow::Result<O, E>
 where
+    O: Uint + FromStr,
     E: ParserError<&'a str>,
 {
     digit1


### PR DESCRIPTION
Replace f64-based timestamp and second parsing with structured types using separate second and nanosecond fields to eliminate floating-point precision issues.