### PR TITLE
fix: use `checked_mul()` to avoid overflow with "week"

### DIFF
--- a/src/items/relative.rs
+++ b/src/items/relative.rs
@@ -111,7 +111,7 @@ fn displacement(input: &mut &str) -> ModalResult<Relative> {
                 "year" => Relative::Years(multipler),
                 "month" => Relative::Months(multipler),
                 "fortnight" => Relative::Days(multipler.checked_mul(14)?),
-                "week" => Relative::Days(7 * multipler),
+                "week" => Relative::Days(multipler.checked_mul(7)?),
                 "day" => Relative::Days(multipler),
                 "hour" => Relative::Hours(multipler),
                 "minute" | "min" => Relative::Minutes(multipler),


### PR DESCRIPTION
https://github.com/uutils/parse_datetime/pull/217 got merged before I could leave a comment. There is another overflow panic possible with "week", which this PR fixes.