### PR TITLE
Bump version to `0.12.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "jiff",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parse_datetime"
 description = "parsing human-readable time strings and converting them to a DateTime"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/uutils/parse_datetime"


### PR DESCRIPTION
As the switch from `chrono` to `jiff` is done, I think it's time for a new release.