### PR TITLE
Bump MSRV to `1.85.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: Basic CI
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
-  RUST_MIN_SRV: "1.71.1"
+  RUST_MIN_SRV: "1.85.1"
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/uutils/parse_datetime"
 readme = "README.md"
-rust-version = "1.71.1"
+rust-version = "1.85.1"
 
 [dependencies]
 winnow = "1.0.0"


### PR DESCRIPTION
This PR bumps the MSRV from `1.71.1` to <del>`1.74.1`</del>`1.85.1` because https://github.com/uutils/parse_datetime/pull/273 introduced a (transitive) dependency that requires a MSRV of <del>`1.74.0`</del>`1.85.0`. It should make the CI green again.