### PR TITLE
ci: use `cargo check` for MSRV check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_MIN_SRV }}
-      - run: cargo test
+      - run: cargo check
 
   coverage:
     name: Code Coverage


### PR DESCRIPTION
This PR uses `cargo check` instead of `cargo test` for the MSRV check in the CI.