### PR TITLE
fix(offset): accept "ut" / "UT" as a bare UTC timezone abbreviation

### DIFF
--- a/src/items/offset.rs
+++ b/src/items/offset.rs
@@ -281,6 +281,7 @@ fn timezone_name_to_offset(input: &str) -> ModalResult<Offset> {
         "w" => Ok("-10"),
         "v" => Ok("-9"),
         "utc" => Ok("+0"),
+        "ut" => Ok("+0"),
         "u" => Ok("-8"),
         "t" => Ok("-7"),
         "sst" => Ok("-11"),
@@ -423,6 +424,7 @@ mod tests {
     fn timezone_name_without_offset() {
         for (input, expected) in [
             ("utc", off(false, 0, 0)),  // UTC
+            ("ut", off(false, 0, 0)),   // Universal Time = UTC (issue #280)
             ("gmt", off(false, 0, 0)),  // UTC
             ("z", off(false, 0, 0)),    // UTC
             ("west", off(false, 1, 0)), // positive offset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,10 +702,7 @@ mod tests {
         for abbr in ["ut", "UT", "gmt", "GMT"] {
             let result = parse_datetime(abbr)
                 .unwrap_or_else(|_| panic!("bare timezone '{abbr}' should be accepted"));
-            let offset_secs = result
-                .expect_in_range()
-                .offset()
-                .seconds();
+            let offset_secs = result.expect_in_range().offset().seconds();
             assert_eq!(offset_secs, 0, "'{abbr}' should resolve to UTC (+0)");
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -694,6 +694,22 @@ mod tests {
         }
     }
 
+    /// GNU `date` accepts bare `ut` / `UT` as a synonym for UTC (issue #280).
+    /// `gmt` and `GMT` already worked; this test covers all four forms.
+    #[test]
+    fn test_bare_utc_timezone_abbreviations() {
+        // All four should parse without error and produce a result in UTC (+00:00).
+        for abbr in ["ut", "UT", "gmt", "GMT"] {
+            let result = parse_datetime(abbr)
+                .unwrap_or_else(|_| panic!("bare timezone '{abbr}' should be accepted"));
+            let offset_secs = result
+                .expect_in_range()
+                .offset()
+                .seconds();
+            assert_eq!(offset_secs, 0, "'{abbr}' should resolve to UTC (+0)");
+        }
+    }
+
     #[test]
     fn test_weekday_only() {
         let now = Zoned::now();


### PR DESCRIPTION
## Summary

- GNU \`date -d\` accepts bare \`ut\` and \`UT\` (Universal Time) as synonyms for UTC. \`parse_datetime\` rejected them with \`InvalidInput\` because \`"ut"\` was absent from the timezone abbreviation table.
- \`gmt\`/\`GMT\` already worked; this is a one-line addition of \`"ut" => "+0"\`.

## Root cause

\`timezone_name_to_offset\` in \`offset.rs\` contained \`"utc"\` and \`"gmt"\` but was missing \`"ut"\`. Since the parser lowercases the input before matching, \`UT\` was also affected.

## Changes

- \`src/items/offset.rs\`: add \`"ut" => Ok("+0")\` to the timezone lookup table; extend the \`timezone_name_without_offset\` unit test to include \`"ut"\`.
- \`src/lib.rs\`: add \`test_bare_utc_timezone_abbreviations\` covering all four forms (\`ut\`, \`UT\`, \`gmt\`, \`GMT\`) end-to-end.

## Test Plan

- [x] \`cargo test\` — all existing tests pass
- [x] New regression test \`test_bare_utc_timezone_abbreviations\` confirms each abbreviation resolves to UTC offset +0

Fixes #280