### PR TITLE
fix(offset): support the military timezone letter `j` (local time)

### DIFF
--- a/src/items/builder.rs
+++ b/src/items/builder.rs
@@ -20,6 +20,10 @@ pub(crate) struct DateTimeBuilder {
     time: Option<time::Time>,
     weekday: Option<weekday::Weekday>,
     offset: Option<offset::Offset>,
+    /// Whether the military timezone letter `j` was given. It is a timezone
+    /// item, so it excludes any other one, but it means local time and so
+    /// contributes no offset of its own.
+    local_zone: bool,
     timezone: Option<jiff::tz::TimeZone>,
     relative: Vec<relative::Relative>,
 }
@@ -59,6 +63,7 @@ impl DateTimeBuilder {
             || self.time.is_some()
             || self.weekday.is_some()
             || self.offset.is_some()
+            || self.local_zone
             || !self.relative.is_empty()
         {
             return Err("timestamp cannot be combined with other date/time items");
@@ -84,7 +89,7 @@ impl DateTimeBuilder {
             return Err("timestamp cannot be combined with other date/time items");
         } else if self.time.is_some() {
             return Err("time cannot appear more than once");
-        } else if self.offset.is_some() && time.offset.is_some() {
+        } else if (self.offset.is_some() || self.local_zone) && time.offset.is_some() {
             return Err("time offset and timezone are mutually exclusive");
         }
 
@@ -107,12 +112,31 @@ impl DateTimeBuilder {
         if self.timestamp.is_some() {
             return Err("timestamp cannot be combined with other date/time items");
         } else if self.offset.is_some()
+            || self.local_zone
             || self.time.as_ref().and_then(|t| t.offset.as_ref()).is_some()
         {
             return Err("time offset cannot appear more than once");
         }
 
         self.offset = Some(timezone);
+        Ok(self)
+    }
+
+    /// Record the military timezone letter `j` (local time).
+    ///
+    /// It occupies the same slot as a numeric offset, so GNU rejects `8j utc`,
+    /// `8 utc j` and `8 j j` as a repeated timezone, and so do we.
+    fn set_local_zone(mut self) -> Result<Self, &'static str> {
+        if self.timestamp.is_some() {
+            return Err("timestamp cannot be combined with other date/time items");
+        } else if self.offset.is_some()
+            || self.local_zone
+            || self.time.as_ref().and_then(|t| t.offset.as_ref()).is_some()
+        {
+            return Err("time offset cannot appear more than once");
+        }
+
+        self.local_zone = true;
         Ok(self)
     }
 
@@ -245,6 +269,7 @@ impl DateTimeBuilder {
             || self.time.is_some()
             || self.weekday.is_some()
             || self.offset.is_some()
+            || self.local_zone
             || has_timezone;
 
         let mut dt = if need_midnight {
@@ -362,6 +387,7 @@ impl DateTimeBuilder {
             time,
             weekday,
             offset,
+            local_zone,
             timezone,
             relative,
         } = self;
@@ -379,6 +405,7 @@ impl DateTimeBuilder {
             || time.is_some()
             || weekday.is_some()
             || offset.is_some()
+            || local_zone
             || has_timezone;
         let mut dt = ExtendedDateTime::new(
             DateParts {
@@ -528,6 +555,7 @@ impl TryFrom<Vec<Item>> for DateTimeBuilder {
                 Item::Time(t) => builder.set_time(t)?,
                 Item::Weekday(weekday) => builder.set_weekday(weekday)?,
                 Item::Offset(offset) => builder.set_offset(offset)?,
+                Item::LocalZone => builder.set_local_zone()?,
                 Item::Relative(rel) => builder.push_relative(rel)?,
                 Item::TimeZone(tz) => builder.set_timezone(tz)?,
                 Item::Pure(pure) => builder.set_pure(pure)?,
@@ -681,6 +709,7 @@ mod tests {
             DateTimeBuilder::new().set_time(time()).unwrap(),
             DateTimeBuilder::new().set_weekday(weekday()).unwrap(),
             DateTimeBuilder::new().set_offset(offset()).unwrap(),
+            DateTimeBuilder::new().set_local_zone().unwrap(),
             DateTimeBuilder::new()
                 .push_relative(relative_day())
                 .unwrap(),
@@ -713,6 +742,10 @@ mod tests {
         );
         assert_eq!(
             ts_builder().set_offset(offset()).unwrap_err(),
+            "timestamp cannot be combined with other date/time items"
+        );
+        assert_eq!(
+            ts_builder().set_local_zone().unwrap_err(),
             "timestamp cannot be combined with other date/time items"
         );
         assert_eq!(

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -69,6 +69,10 @@ enum Item {
     Weekday(weekday::Weekday),
     Relative(relative::Relative),
     Offset(offset::Offset),
+    /// The military timezone letter `j`, which GNU `date` defines as local
+    /// time. It is a timezone item like [`Item::Offset`], but carries no
+    /// offset, so it cannot be represented as one.
+    LocalZone,
     TimeZone(jiff::tz::TimeZone),
     Pure(String),
 }
@@ -260,6 +264,7 @@ fn parse_item(input: &mut &str) -> ModalResult<Item> {
             relative::parse.map(Item::Relative),
             weekday::parse.map(Item::Weekday),
             offset::parse.map(Item::Offset),
+            offset::parse_local.map(|()| Item::LocalZone),
             pure::parse.map(Item::Pure),
         )),
     )
@@ -784,5 +789,31 @@ mod tests {
         ] {
             assert_eq!(parse_build(input), expected, "{input}");
         }
+    }
+    /// `j` is a time zone item, so it participates in the same duplicate check
+    /// as a numeric offset. GNU rejects all three of these as a repeated zone.
+    #[test]
+    fn military_j_is_a_timezone_item() {
+        // Parses on its own, attached or spaced, in either case.
+        for input in ["j", "8j", "8 j", "8J", "j 8"] {
+            assert!(parse(&mut &*input).is_ok(), "`{input}` should parse");
+        }
+
+        for input in ["8j utc", "8 utc j", "8 j j"] {
+            let result = parse(&mut &*input);
+            assert!(result.is_err(), "`{input}` should be rejected");
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("time offset cannot appear more than once"),
+                "`{input}` should report a repeated time offset"
+            );
+        }
+
+        // A bare numeric offset is not an item on its own (the grammar requires
+        // a named zone), so this is rejected by the parser rather than by the
+        // duplicate check. GNU rejects it too.
+        assert!(parse(&mut "j +05:00").is_err());
     }
 }

--- a/src/items/offset.rs
+++ b/src/items/offset.rs
@@ -168,8 +168,28 @@ impl Display for Offset {
     }
 }
 
+/// I'm assuming there are no timezone abbreviations with more
+/// than 6 charactres
+const MAX_TZ_SIZE: usize = 6;
+
 pub(super) fn parse(input: &mut &str) -> ModalResult<Offset> {
     timezone_name_offset.parse_next(input)
+}
+
+/// Parse the military timezone letter `j`.
+///
+/// Every other military letter denotes a fixed offset from UTC, but GNU `date`
+/// defines `j` as local time, which cannot be expressed as an [`Offset`] at
+/// all. It is therefore reported to the builder as its own item.
+///
+/// The whole alphabetic word is consumed before comparing, so `jan` is left to
+/// the date parser rather than being read as `j` followed by `an`, and `jj` is
+/// rejected rather than matching a `j` prefix.
+pub(super) fn parse_local(input: &mut &str) -> ModalResult<()> {
+    s(take_while(1..=MAX_TZ_SIZE, AsChar::is_alpha))
+        .verify(|word: &str| word.eq_ignore_ascii_case("j"))
+        .void()
+        .parse_next(input)
 }
 
 /// Parse a timezone starting with `+` or `-`.
@@ -188,9 +208,6 @@ pub(super) fn timezone_offset(input: &mut &str) -> ModalResult<Offset> {
 
 /// Parse a timezone by name, with an optional numeric offset appended.
 fn timezone_name_offset(input: &mut &str) -> ModalResult<Offset> {
-    /// I'm assuming there are no timezone abbreviations with more
-    /// than 6 charactres
-    const MAX_TZ_SIZE: usize = 6;
     let nextword = s(take_while(1..=MAX_TZ_SIZE, AsChar::is_alpha)).parse_next(input)?;
     let tz = timezone_name_to_offset(nextword)?;
 
@@ -493,5 +510,32 @@ mod tests {
         assert_eq!(off(false, 5, 30).total_seconds(), 19_800);
         assert_eq!(off(true, 5, 30).total_seconds(), -19_800);
         assert_eq!(off(false, 24, 0).total_seconds(), 86_400);
+    }
+    /// `j` is the one military letter that is not an offset, so it is parsed
+    /// separately. The whole alphabetic word must be consumed before matching,
+    /// otherwise `jan` would be read as `j` followed by `an`.
+    #[test]
+    fn military_letter_j_local() {
+        for input in ["j", "J", " j"] {
+            let mut s = input;
+            assert!(
+                parse_local(&mut s).is_ok(),
+                "`{input}` should parse as local time"
+            );
+            assert!(s.is_empty(), "`{input}` should be fully consumed");
+        }
+
+        for input in ["jj", "jan", "jst", "z", "a", ""] {
+            let mut s = input;
+            assert!(
+                parse_local(&mut s).is_err(),
+                "`{input}` should not parse as local time"
+            );
+        }
+
+        // `j` is absent from the offset table, so the offset parser must not
+        // claim it.
+        let mut s = "j";
+        assert!(timezone_name_offset(&mut s).is_err());
     }
 }

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -325,3 +325,74 @@ fn test_utc_keyword_plus_relative_seconds_across_dst() {
         .expect_in_range();
     assert_eq!(parsed.timestamp().as_second(), seconds);
 }
+
+// The military time zone letter `j`.
+//
+// Every other military letter (`a`-`i`, `k`-`y`, and `z` for UTC) denotes a
+// fixed offset from UTC. GNU `date` defines `j` as *local* time instead, so it
+// follows the base zone's DST rules rather than pinning an offset:
+//
+//   $ TZ=America/New_York date -d '8j'           # 2026-08-25 08:00 -0400
+//   $ TZ=America/New_York date -d '2026-01-01 j' # 2026-01-01 00:00 -0500
+//   $ TZ=America/New_York date -d '8z'           # 2026-08-25 04:00 -0400
+//
+// Verified against GNU coreutils 9.4.
+#[rstest]
+// Winter: New York is on EST (UTC-5).
+#[case::est("2026-01-15 12:00:00", -5 * 3600)]
+// Summer: the same zone is on EDT (UTC-4). A fixed offset could not do this.
+#[case::edt("2026-07-15 12:00:00", -4 * 3600)]
+fn test_military_j_is_local_time(#[case] base: &str, #[case] expected_offset: i32) {
+    let base = base
+        .parse::<DateTime>()
+        .unwrap()
+        .to_zoned(TimeZone::get("America/New_York").unwrap())
+        .unwrap();
+
+    let parsed = parse_datetime::parse_datetime_at_date(base.clone(), "8j")
+        .unwrap()
+        .expect_in_range();
+
+    assert_eq!(parsed.hour(), 8, "`8j` should be 08:00 local");
+    assert_eq!(
+        parsed.offset().seconds(),
+        expected_offset,
+        "`8j` should take the base zone's offset"
+    );
+
+    // `z` is UTC, so it must *not* follow the base zone. This is what
+    // distinguishes `j` from every other military letter.
+    let utc = parse_datetime::parse_datetime_at_date(base, "8z")
+        .unwrap()
+        .expect_in_range();
+    assert_eq!(utc.offset().seconds(), 0, "`8z` should be UTC");
+}
+
+#[rstest]
+#[case::bare("j")]
+#[case::attached("8j")]
+#[case::uppercase("8J")]
+#[case::spaced("8 j")]
+#[case::leading("j 8")]
+fn test_military_j_accepted(#[case] input: &str) {
+    assert!(
+        parse_datetime::parse_datetime(input).is_ok(),
+        "`{input}` should parse"
+    );
+}
+
+#[rstest]
+// `j` is a time zone item, so a second one is a repeated zone, as in GNU.
+#[case::j_then_utc("8j utc")]
+#[case::utc_then_j("8 utc j")]
+#[case::j_twice("8 j j")]
+#[case::j_then_numeric("j +05:00")]
+// The whole alphabetic word is matched, so `j` never steals a prefix.
+#[case::doubled_letter("jj")]
+#[case::doubled_letter_after_number("8 jj")]
+fn test_military_j_rejected(#[case] input: &str) {
+    assert!(
+        parse_datetime::parse_datetime(input).is_err(),
+        "`{input}` should be rejected, as GNU date does"
+    );
+}


### PR DESCRIPTION
GNU `date` accepts every letter `a`–`y` as a military time zone. All of them are already in our table except one: `j`.

It is missing for a reason. `j` is the single letter that does **not** denote a fixed offset — it means *local time*, so it cannot be expressed as an `Offset` at all.

### What GNU actually does

Verified against GNU coreutils 9.4, in `TZ=America/New_York` (EDT, UTC−4):

| input | GNU result | meaning |
|---|---|---|
| `8a` | `08:00 +01:00` | UTC+1 |
| `8n` | `08:00 −01:00` | UTC−1 |
| `8z` | `04:00 −0400` | UTC |
| `8j` | `08:00 −0400` | **local** — identical to bare `8` |
| `2026-01-01 j` | `00:00 −0500` | **local, DST-aware** |
| `8foo` | invalid date | unknown words are errors |

The `2026-01-01 j` row is the important one: it resolves to −05:00 in January and −04:00 in August. It follows the zone's DST rules, so no fixed offset can represent it.

### The change

`j` is parsed as its own item and recorded on the builder as a flag rather than as an offset, so the local rule zone is used instead of a fixed one.

- `8j`, `8 j`, `j 8` and `8J` all work.
- It is still a *time zone item*, so `8j utc`, `8 utc j` and `8 j j` are rejected as a repeated zone, matching GNU.
- The whole alphabetic word is consumed before comparing, so `8jan` still parses as a date and `jj` is rejected rather than matching a `j` prefix.
- Unknown words stay errors — `8foo` still fails, as it does in GNU.

### Verification

I compared every letter `a`–`z` against GNU coreutils 9.4, comparing resolved Unix timestamps in a DST zone:

```
8a gnu=1787641200  pd=1787641200  ok
...
8j gnu=1787659200  pd=1787659200  ok
...
8z gnu=1787644800  pd=1787644800  ok
=== mismatches: 0 ===
```

All 26 letters now resolve to the same instant as GNU. 403 tests pass, fmt and clippy clean.

### Relationship to #286

This supersedes #286, and confirms @sylvestre's review there was correct.

#286 assumed GNU silently discards unrecognized trailing alphabetic tokens after a number. It does not — `date -d '8foo'` is an *invalid date*. The only such token GNU actually accepts is `j`, and for a reason #286 did not model: it is a time zone, not noise to be skipped.

#286 has also drifted five months behind `main` and its diff would revert several later fixes, so this is a fresh branch from current `main` rather than an update to it.