### PR TITLE
fix(offset): accept MEZ, MESZ, MEST and KST abbreviations

### DIFF
--- a/src/items/offset.rs
+++ b/src/items/offset.rs
@@ -302,9 +302,13 @@ fn timezone_name_to_offset(input: &str) -> ModalResult<Offset> {
         "mst" => Ok("-7"),
         "msk" => Ok("+3"),
         "msd" => Ok("+4"),
+        "mez" => Ok("+1"),
+        "mesz" => Ok("+2"),
+        "mest" => Ok("+2"),
         "mdt" => Ok("-6"),
         "m" => Ok("+12"),
         "l" => Ok("+11"),
+        "kst" => Ok("+9"),
         "k" => Ok("+10"),
         "jst" => Ok("+9"),
         "ist" => Ok("+5:30"),
@@ -431,6 +435,12 @@ mod tests {
             ("cst", off(true, 6, 0)),   // negative offset
             ("ist", off(false, 5, 30)), // positive offset with non-zero minutes
             ("nst", off(true, 3, 30)),  // negative offset with non-zero minutes
+            // Accepted by GNU date but previously missing here, which made
+            // `date -d "2024-01-15 12:00 MEZ"` fail (uutils/coreutils#13865).
+            ("mez", off(false, 1, 0)),
+            ("mesz", off(false, 2, 0)),
+            ("mest", off(false, 2, 0)),
+            ("kst", off(false, 9, 0)),
             ("z123", off(false, 0, 0)), // space separator can be ignored if immediately followed by digits (GNU date behavior)
         ] {
             let mut s = input;


### PR DESCRIPTION
`timezone_name_to_offset` documents its own scope as matching GNU:

> GNU date only supports a subset of these. We support the same subset as GNU date.

Four abbreviations GNU accepts are missing from the table, so they fail here:

```console
$ TZ=UTC date -u -d '2024-01-15 12:00 MEZ' +%H:%M
11:00
```

`MEZ` is +1, `MESZ` and `MEST` are +2, and `KST` is +9.

## How these four were picked

Rather than adding only the ones I happened to run into, I compared the crate against GNU across 100 candidate abbreviations: everything already in this table, plus the ones `uutils/coreutils` carries in `date.rs`, plus a spread of common world abbreviations. GNU accepted 72 of them and the crate agreed on 63. The other nine fall into two groups.

Four the crate rejects outright. Those are in this PR.

Five where both accept but the offsets disagree: `ADT`, `AST`, `BST`, `GST` and `SST`. Every one of those is a genuinely ambiguous name (Atlantic or Arabia, British or Bangladesh, Gulf or Guam), and changing a value that already exists is a different sort of decision from filling a hole. I left them alone. Happy to open an issue with the measurements if you want them tracked.

## Where the offsets came from

Each one was measured by running GNU date and comparing instants, for example:

```console
$ TZ=UTC date -u -d '2024-01-15 12:00 KST' +%H:%M
03:00
```

GNU coreutils 9.1. These came from running GNU date and reading its output, not from reading its source.

## Tests

The four are added to the existing `timezone_name_without_offset` list. That test fails before the change and passes after. The rest of the suite is unaffected.

## Context

This gap is part of why `uutils/coreutils` keeps a separate abbreviation table in `date.rs`, which came up in uutils/coreutils#13865. This change does not remove that table on its own, and the two are independent.
