### PR TITLE
fix(offset): correct ADT, AST, BST and GST to GNU's values

### DIFF
--- a/src/items/offset.rs
+++ b/src/items/offset.rs
@@ -331,7 +331,7 @@ fn timezone_name_to_offset(input: &str) -> ModalResult<Offset> {
         "i" => Ok("+9"),
         "hst" => Ok("-10"),
         "h" => Ok("+8"),
-        "gst" => Ok("+4"),
+        "gst" => Ok("+10"),
         "gmt" => Ok("+0"),
         "g" => Ok("+7"),
         "f" => Ok("+6"),
@@ -350,15 +350,15 @@ fn timezone_name_to_offset(input: &str) -> ModalResult<Offset> {
         "cdt" => Ok("-5"),
         "cat" => Ok("+2"),
         "c" => Ok("+3"),
-        "bst" => Ok("+6"),
+        "bst" => Ok("+1"),
         "brt" => Ok("-3"),
         "brst" => Ok("-2"),
         "b" => Ok("+2"),
-        "ast" => Ok("-3"),
+        "ast" => Ok("-4"),
         "art" => Ok("-3"),
         "akst" => Ok("-9"),
         "akdt" => Ok("-8"),
-        "adt" => Ok("+4"),
+        "adt" => Ok("-3"),
         "a" => Ok("+1"),
         _ => Err(ErrMode::Backtrack(ContextError::new())),
     }?;
@@ -457,6 +457,14 @@ mod tests {
             ("mesz", off(false, 2, 0)),
             ("mest", off(false, 2, 0)),
             ("kst", off(false, 9, 0)),
+            // Each of these resolved to a different real meaning of the
+            // abbreviation than the one GNU date uses, e.g. BST as Bangladesh
+            // Standard Time rather than British Summer Time.
+            ("adt", off(true, 3, 0)),   // Atlantic Daylight, was +4
+            ("ast", off(true, 4, 0)),   // Atlantic Standard, was -3
+            ("bst", off(false, 1, 0)),  // British Summer, was +6
+            ("gst", off(false, 10, 0)), // Guam Standard, was +4
+            ("sst", off(true, 11, 0)),
             ("z123", off(false, 0, 0)), // space separator can be ignored if immediately followed by digits (GNU date behavior)
         ] {
             let mut s = input;


### PR DESCRIPTION
`timezone_name_to_offset` documents its own scope as matching GNU:

> GNU date only supports a subset of these. We support the same subset as GNU date.

This is the follow-up to #321, which measured the crate against GNU across 100 candidate abbreviations and found five where both accept the name but the offsets disagree. This PR corrects four of them to their tz database offsets, each a real behaviour fix for current users:

- `ADT` -3 (was +4)
- `AST` -4 (was -3)
- `BST` +1 (was +6)
- `GST` +10 (was +4)

For example, `parse_datetime("2026-06-15 12:00 BST")` currently returns +06:00, which is Bangladesh Standard Time, where GNU says BST is +1 (British Summer Time).

### How the offsets were verified

With `zdump` against the tz databases of macOS 16 and Debian stable; both agree on every value above:

- `ADT` -03, `AST` -04 via `America/Halifax`
- `BST` +01 via `Europe/London`
- `GST` +10 via `Pacific/Guam`

One finding from the verification itself: GNU date ignores a bare abbreviation token in a date string entirely (verified on 9.7 Linux and 9.11 macOS), so the tz database is the operative reference for what these names mean, and that is what the table was checked against.

### The fifth disagreement, `SST`, is deliberately not touched

The #321 measurements recorded GNU as resolving `SST` to -12, but the tz database binds `SST` to -11 (via `Pacific/Pago_Pago` and `Pacific/Midway`) and no zone binds it to -12; the same scan on macOS and Debian tzdata agrees. Since the two authorities conflict on this one name, this PR leaves `SST` at its current -11 and flags the disagreement rather than guessing. Happy to change it if the GNU reading of -12 has a source I could not find.

Tests assert the four corrected values and fail without the fix.
