### PR TITLE
fix(offset): treat a numeric offset after a time of day as a zone correction

### DIFF
--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -816,4 +816,47 @@ mod tests {
         // duplicate check. GNU rejects it too.
         assert!(parse(&mut "j +05:00").is_err());
     }
+    /// A numeric offset after a time of day is a time zone correction, even
+    /// when a relative item follows it. GNU `date` reads
+    /// `2026-08-27 12:00 +3 hours` as the zone `+03:00` plus a bare `hours`
+    /// (which means one hour), i.e. 10:00 UTC.
+    #[test]
+    fn numeric_offset_before_relative_item() {
+        for (expected, input) in [
+            ("2026-08-27 10:00:00", "2026-08-27 12:00 +3 hours"),
+            ("2026-08-27 10:00:00", "2026-08-27 12:00 +3 hour"),
+            ("2026-08-27 10:00:00", "2026-08-27 12:00 +3hours"),
+            ("2026-08-27 10:00:00", "2026-08-27 12:00 + 3 hours"),
+            ("2026-08-27 10:00:00", "2026-08-27 12:00 +03 hours"),
+            ("2026-08-27 10:00:00", "2026-08-27 12:00 +0300 hours"),
+            ("2026-08-27 10:00:00", "2026-08-27 12:00:00 +3 hours"),
+            ("2026-08-27 10:05:00", "2026-08-27 12:00 +3 hours 5 minutes"),
+            ("2026-08-27 08:00:00", "2026-08-27 12:00 +3 hours ago"),
+            ("2026-08-28 09:00:00", "2026-08-27 12:00 +3 days"),
+            ("2026-08-27 09:01:00", "2026-08-27 12:00 +3 minutes"),
+            ("2026-08-27 16:00:00", "2026-08-27 12:00 -3 hours"),
+            ("2026-08-27 00:00:00", "2026-08-27 12:00 +13 hours"),
+            // A named zone already fills the zone slot, so the numeric value
+            // stays a relative item.
+            ("2026-08-27 15:00:00", "2026-08-27 12:00 utc +3 hours"),
+            // Without a time of day there is no zone slot to fill either.
+            ("2026-08-27 03:00:00", "2026-08-27 +3 hours"),
+            // A fractional number is never a zone correction.
+            ("2026-08-27 12:00:01", "2026-08-27 12:00 +1.5 seconds"),
+        ] {
+            let parsed = parse(&mut &*input)
+                .map(at_utc)
+                .expect("parsing failed during tests")
+                .with_time_zone(TimeZone::UTC);
+            assert_eq!(
+                expected,
+                parsed.strftime("%Y-%m-%d %H:%M:%S").to_string(),
+                "{input}"
+            );
+        }
+
+        // `+30` is not a valid zone correction, and GNU rejects the whole
+        // input rather than falling back to a relative item.
+        assert!(parse(&mut "2026-08-27 12:00 +30 hours").is_err());
+    }
 }

--- a/src/items/offset.rs
+++ b/src/items/offset.rs
@@ -31,7 +31,7 @@ use winnow::{
     combinator::{alt, peek},
     error::{ContextError, ErrMode},
     stream::{AsChar, Stream},
-    token::take_while,
+    token::{one_of, take_while},
     ModalResult, Parser,
 };
 
@@ -193,12 +193,18 @@ pub(super) fn parse_local(input: &mut &str) -> ModalResult<()> {
 
 /// Parse a timezone starting with `+` or `-`.
 pub(super) fn timezone_offset(input: &mut &str) -> ModalResult<Offset> {
-    // Strings like "+8 years" are ambiguous, they can either be parsed as a
-    // timezone offset "+8" and a relative time "years", or just a relative time
-    // "+8 years". GNU date parses them the second way, so we do the same here.
-    //
-    // Return early if the input can be parsed as a relative time.
-    if peek(relative::parse).parse_next(input).is_ok() {
+    // A number with a fractional part is never a zone correction: GNU `date`
+    // reads `12:00 +1.5 seconds` as the relative item `+1.5 seconds`, not as
+    // the offset `+01:00` followed by a stray `.5 seconds`. Backtrack so that
+    // the relative parser gets a chance at it.
+    let fraction: ModalResult<_> = peek((
+        plus_or_minus,
+        s(dec_uint_str),
+        '.',
+        one_of(AsChar::is_dec_digit),
+    ))
+    .parse_next(input);
+    if fraction.is_ok() {
         return Err(ErrMode::Backtrack(ContextError::new()));
     }
 
@@ -433,7 +439,7 @@ mod tests {
             "+2500",    // invalid: hours > 24
             "-2361",    // invalid: minutes > 60
             "+2401",    // invalid: minutes > 0 when hours == 24
-            "+23 days", // invalid: ambiguous with relative time parsing
+            "+25 days", // invalid: hours > 24, even when followed by a relative item
         ] {
             let mut s = input;
             assert!(timezone_offset(&mut s).is_err(), "{input}");


### PR DESCRIPTION
`2026-08-27 12:00 +3 hours` is parsed as a relative shift of three hours. GNU
`date` parses the `+3` as the time zone correction `+03:00` and the bare
`hours` as a relative item with an implicit count of one:

```console
$ date -u -d '2026-08-27 12:00 +3 hours'   # GNU 9.11
2026-08-27 10:00:00 UTC
$ date -u -d '2026-08-27 12:00 +3 hours'   # uutils, before
2026-08-27 15:00:00 UTC
```

`+3` alone already parsed as a zone (`12:00 +3` → 09:00), so the reading of the
number flipped depending on whether a unit word happened to follow it.

## The rule

Both halves are documented in the GNU manual. From "Time zone items in date
strings": a time of day may be followed by a time zone correction, e.g.
`+0530`, `-05:30`, and `+3` is such a correction. From "Relative items in date
strings": *"The unit of time displacement may be selected by the string 'year'
… A unit of time with no number means 1."* So `+3 hours` after a time of day is
the zone `+03:00` plus one hour: 12:00+03:00 = 09:00 UTC, +1h = 10:00 UTC.

The zone slot is filled only once and only by a time of day, which is why the
cases below stay relative in GNU, and stayed correct here:

```console
$ date -u -d '2026-08-27 12:00 UTC +3 hours'   # zone slot already taken
2026-08-27 15:00:00 UTC
$ date -u -d '2026-08-27 +3 hours'             # no time of day, no zone slot
2026-08-27 03:00:00 UTC
```

## The change

`timezone_offset` backtracked whenever the remaining input parsed as a relative
item, with a comment stating that GNU prefers the relative reading for
`+8 years`. It does not — the transcripts above show the opposite. The guard is
dropped.

One narrow case really is a relative item and keeps a guard: a number with a
fractional part cannot be a zone correction, and GNU reads it as a relative
item.

```console
$ date -u -d '2026-08-27 12:00 +1.5 seconds'   # GNU
2026-08-27 12:00:01 UTC
$ date -u -d '2026-08-27 12:00 +2.5 hours'     # GNU: only seconds take a fraction
date: invalid date '2026-08-27 12:00 +2.5 hours'
```

That is why the new check tests for a fraction specifically rather than for a
relative item, and why it runs *before* the offset is parsed and range-checked:
`+25.5 seconds` is a valid relative item even though `+25` is not a valid zone.

An out-of-range correction is now a hard error rather than a silent fallback to
a relative reading, which is what GNU does:

```console
$ date -u -d '2026-08-27 12:00 +30 hours'   # GNU
date: invalid date '2026-08-27 12:00 +30 hours'
```

The existing `"+23 days"` case in `timezone_offset_without_colon` asserted the
old behavior and is replaced by `"+25 days"`, which is still rejected, now
because 25 is not a valid hour offset.

## How the GNU behavior was established

By running the installed GNU binary (coreutils 9.11) as a black box and
recording its output, plus the two manual sections quoted above. I did not read
GNU coreutils source.

## Testing

- `cargo test`: **418 passed, 0 failed** (417 pre-existing, plus the new
  `numeric_offset_before_relative_item`). Two tests, `floating_seconds_offset`
  and `floating_seconds_offset_spaceless` (`0 + 0.0 seconds`), fail without the
  fraction guard — they are the mutation check for that half of the change and
  needed no modification.
- `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings`:
  clean.
- Differential A/B against GNU 9.11: 2520 inputs built from 14 date/time bases
  × 20 numeric prefixes (`+3`, `-3`, `+0300`, `+05:30`, `+1.5`, `+25`, bare, …)
  × relative units × `ago`. **400 cases moved from differing to identical, 0
  regressions.**

The 162 cases that still differ are pre-existing and unrelated: fractional
seconds round instead of truncating (`-0.5 secs` → `11:59:58` vs GNU
`11:59:59`), and `<zone> +N <unit> ago` is accepted here while GNU rejects it.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the uutils AI
policy. Every GNU behavior quoted above came from running the installed binary
and reading the GNU manual, not from reading GPL source. All testing was run
locally.
