### PR TITLE
fix(relative): add the fraction of a negative relative second count

### DIFF
--- a/src/items/relative.rs
+++ b/src/items/relative.rs
@@ -59,9 +59,23 @@ impl TryFrom<Relative> for jiff::Span {
             Relative::Days(days) => jiff::Span::new().try_days(days),
             Relative::Hours(hours) => jiff::Span::new().try_hours(hours),
             Relative::Minutes(minutes) => jiff::Span::new().try_minutes(minutes),
-            Relative::Seconds(seconds, nanoseconds) => jiff::Span::new()
-                .try_seconds(seconds)
-                .and_then(|span| span.try_nanoseconds(nanoseconds)),
+            Relative::Seconds(seconds, nanoseconds) => {
+                // `Relative::Seconds` is a floor decomposition: the value is
+                // `seconds + nanoseconds / 1e9` with a non-negative fraction, so
+                // -0.25 seconds is held as `(-1, 750_000_000)`. A `jiff::Span`
+                // is sign-uniform, so the fraction has to be rebalanced onto the
+                // sign of the whole seconds first; combining the fields as they
+                // are would subtract the fraction instead of adding it.
+                let (seconds, nanoseconds) = if seconds < 0 && nanoseconds > 0 {
+                    (seconds + 1, -i64::from(1_000_000_000 - nanoseconds))
+                } else {
+                    (seconds, i64::from(nanoseconds))
+                };
+
+                jiff::Span::new()
+                    .try_seconds(seconds)
+                    .and_then(|span| span.try_nanoseconds(nanoseconds))
+            }
         }
         .map_err(|_| "relative value is invalid")
     }

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -280,3 +280,39 @@ fn test_time_seconds_ago_invalid(#[case] input: &str) {
         "Input string '{input}' did not produce an error when parsing"
     );
 }
+
+// Fractional relative seconds, checked against GNU date 9.11 with
+// TZ=UTC date --date="2026-08-27 12:00:00 <input>" +"%H:%M:%S.%N"
+#[rstest]
+#[case::plus_half("+0.5 sec", "12:00:00.500000000")]
+#[case::minus_half("-0.5 sec", "11:59:59.500000000")]
+#[case::plus_one_and_a_half("+1.5 sec", "12:00:01.500000000")]
+#[case::minus_one_and_a_half("-1.5 sec", "11:59:58.500000000")]
+#[case::plus_quarter("+0.25 sec", "12:00:00.250000000")]
+#[case::minus_quarter("-0.25 sec", "11:59:59.750000000")]
+#[case::plus_one_and_three_quarters("+1.75 sec", "12:00:01.750000000")]
+#[case::minus_one_and_three_quarters("-1.75 sec", "11:59:58.250000000")]
+#[case::plus_two_and_an_eighth("+2.125 sec", "12:00:02.125000000")]
+#[case::minus_two_and_an_eighth("-2.125 sec", "11:59:57.875000000")]
+#[case::minus_nine_nanoseconds("-0.000000009 sec", "11:59:59.999999991")]
+#[case::minus_almost_one("-0.999999999 sec", "11:59:59.000000001")]
+#[case::plus_half_ago("+0.5 sec ago", "11:59:59.500000000")]
+#[case::minus_half_ago("-0.5 sec ago", "12:00:00.500000000")]
+#[case::plus_one_and_a_half_ago("+1.5 sec ago", "11:59:58.500000000")]
+#[case::unsigned_half_ago("0.5 sec ago", "11:59:59.500000000")]
+#[case::unsigned_half("0.5 sec", "12:00:00.500000000")]
+#[case::plus_zero_fraction("+0.0 sec", "12:00:00.000000000")]
+#[case::minus_zero_fraction("-0.0 sec", "12:00:00.000000000")]
+#[case::minus_whole_with_fraction_zero("-1.0 sec", "11:59:59.000000000")]
+#[case::minus_whole("-1 second ago", "12:00:01.000000000")]
+#[case::plural_minus_half("-0.5 seconds", "11:59:59.500000000")]
+#[case::abbreviated_minus_half("-0.5 secs", "11:59:59.500000000")]
+fn test_relative_fractional_seconds(#[case] input: &str, #[case] expected: &str) {
+    let base = "2026-08-27 12:00:00"
+        .parse::<DateTime>()
+        .unwrap()
+        .to_zoned(TimeZone::UTC)
+        .unwrap();
+
+    check_time(input, expected, "%H:%M:%S.%N", Some(base));
+}


### PR DESCRIPTION
`2026-08-27 12:00:00 -0.25 seconds` lands 1.5 seconds early. The fraction of a
negative relative second count is subtracted instead of added:

```console
$ TZ=UTC date -d '2026-08-27 12:00:00 -0.25 sec' +'%H:%M:%S.%N'   # GNU 9.11
11:59:59.750000000
$ TZ=UTC date -d '2026-08-27 12:00:00 -0.25 sec' +'%H:%M:%S.%N'   # uutils, before
11:59:58.250000000
```

The error is `2 * (1 - fraction)` seconds, so it grows as the fraction shrinks —
`-0.000000009 sec` was off by very nearly two full seconds. Positive counts were
always correct, and so were the equivalents written with `ago`
(`+0.25 sec ago` was wrong, `-0.25 sec ago` was right), because only the sign of
the resulting count matters.

## The rule

From the GNU manual, "Relative items in date strings": *"The unit of time may be
preceded by a multiplier, given as an optionally signed number… Following a
relative item by the string 'ago' is equivalent to preceding the unit by a
multiplier with value -1."* A multiplier of -0.25 on the unit `second` displaces
the date by a quarter second backwards; nothing about the sign changes the
magnitude. GNU applies exactly that, keeping the fraction intact rather than
rounding or truncating it — every `%N` above is exact.

Fractions are accepted on `second` only, in GNU and here alike, so this is the
whole surface of the bug.

## The change

`Relative::Seconds(i64, u32)` is a floor decomposition: the value is
`seconds + nanoseconds / 1e9` with a non-negative fraction, so -0.25 seconds is
held as `(-1, 750_000_000)`. That representation is correct, and the
`ExtendedDateTime` path (years above 9999) consumes it correctly with
`checked_add_seconds`, which adds the positive fraction and carries.

The in-range path builds a `jiff::Span` instead, and a `Span` is sign-uniform:
`Span::new().try_seconds(-1).try_nanoseconds(750_000_000)` is -1.75s, not
-0.25s. The two fields are now rebalanced onto a common sign — `(-1,
+750_000_000)` becomes `(0, -250_000_000)` — before the span is built. `seconds`
is negative in that branch, so `seconds + 1` cannot overflow.

No representation or public API changes, and the extended-year path is
untouched.

## How the GNU behavior was established

By running the installed GNU binary (coreutils 9.11) as a black box with
`+'%H:%M:%S.%N'` so the fraction is visible, plus the manual section quoted
above. I did not read GNU coreutils source.

## Testing

- `cargo test`: **440 passed, 0 failed** (417 pre-existing, plus 23 new
  `test_relative_fractional_seconds` cases whose expectations were taken from
  GNU 9.11 transcripts).
- Mutation check on the new test, all three caught: dropping the rebalance
  entirely fails 12 of 23 cases, flipping the sign of the fraction fails 8,
  and an off-by-one on the borrow (`seconds - 1`) fails 12.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`: clean.
- Differential A/B against GNU 9.11 over the same 2520-input corpus used in
  #326: **18 cases moved from differing to identical, 0 regressions**
  (562 → 544 on `main`; stacked on #326 it is 162 → 144).

This is independent of #326 — it reproduces on `main` and the branch is cut from
`main` — but the two touch the same inputs, so whichever lands second will want
a rebase.

The 144 cases that still differ are one pre-existing class: `<zone> +N <unit>
ago` is accepted here and rejected by GNU. That one looks like a GNU parser
artifact rather than a rule to copy — the manual defines `ago` as a -1
multiplier, GNU itself accepts `UTC +1 year 1 day ago`, and in
`UTC +1 hour +0 sec ago` GNU silently ignores the `ago` instead of erroring — so
I have left it alone.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the uutils AI
policy. Every GNU behavior quoted above came from running the installed binary
and reading the GNU manual, not from reading GPL source. All testing was run
locally.
